### PR TITLE
Fix #47 - Add stash support

### DIFF
--- a/workflow/4-generate_mlbf
+++ b/workflow/4-generate_mlbf
@@ -42,9 +42,9 @@ def main():
             dest.mkdir()
 
             workflow.download_from_google_cloud(bucket_name, f"{latest}/mlbf/filter",
-                                                dest / Path("filter"))
+                                                dest / Path("list-revoked.keys"))
             workflow.download_from_google_cloud(bucket_name, f"{latest}/mlbf/filter.meta",
-                                                dest / Path("filter.meta"))
+                                                dest / Path("list-valid.keys"))
 
             cmdline = cmdline + ["-previd", dest]
         except exceptions.NotFound as e:


### PR DESCRIPTION
This by default generates an `mlbf` file named `filter.stash`, which contains
all the additions to the filter, collated by issuer and status change.

The file is made of per-issuer blocks, where each block's bytes are:

```
  bytes 0-3: N, number of revoked serials as an unsigned long
  bytes 4-7: M, number of nonrevoked serials as an unsigned long
  bytes 8-9: L, length of the issuer field as a unsigned short
  bytes 10+: hash of issuer subject public key info of length L
  ... then N serials_structs
  ... followed by M serials_structs
```

The serials_struct blocks are defined:
```
  bytes 0-1: S, length of serial field as an unsigned short
  bytes 2+: ASN.1 DER-encoded serial number of length S
```

When reaching EOF, there are no more issuer blocks.

Consumers can collect these `filter.stash` files, load them in chronological
order, and apply them before querying the originating MLBF filter.