### PR TITLE
Stash fixes

### DIFF
--- a/create_filter_cascade/certs_to_crlite.py
+++ b/create_filter_cascade/certs_to_crlite.py
@@ -84,8 +84,8 @@ def createCertLists(*, known_path, revoked_path, known_revoked_path, known_nonre
                                                      revokedPath=revoked_path,
                                                      excludeIssuer=exclude_issuer)
         for issuerObj in sorted(issuerPathIter, key=lambda i: i.issuer):
-            log.info(f"createCertLists Processing issuerObj={issuerObj}, "
-                     + f"memory={psutil.virtual_memory()}")
+            log.debug(f"createCertLists Processing issuerObj={issuerObj}, "
+                      + f"memory={psutil.virtual_memory()}")
 
             issuer = issuerObj.issuer
             initIssuerStats(stats, issuer)
@@ -313,11 +313,11 @@ def main():
         prior_revoked_path = prior_folder / Path("list-revoked.keys")
         prior_valid_path = prior_folder / Path("list-valid.keys")
         if not (prior_revoked_path.is_file() and prior_valid_path.is_file()):
-            log.warning("Previous ID specified but no filter files found.")
+            log.warning("Diff: Previous ID specified but no filter files found.")
         else:
             sw.start('make diff')
             try:
-                log.info("Making diff for known revoked entries")
+                log.info("Diff: Making diff for known revoked entries")
                 with open(prior_revoked_path,
                           "rb") as prior_fp, open(args.revokedKeys, "rb") as fp:
                     sw.start('diff revoked filter')
@@ -327,7 +327,7 @@ def main():
                     )
                     sw.end('diff revoked filter')
 
-                log.info("Making diff for known valid entries")
+                log.info("Diff: Making diff for known valid entries")
                 with open(prior_valid_path, "rb") as prior_fp, open(args.validKeys, "rb") as fp:
                     sw.start('diff valid filter')
                     nonrevoked_diff_by_issuer = find_additions(
@@ -336,7 +336,7 @@ def main():
                     )
                     sw.end('diff valid filter')
 
-                log.info("Saving difference stash.")
+                log.info("Diff: Saving difference stash.")
                 crlite.save_additions(
                     out_path=args.diffPath,
                     revoked_by_issuer=revoked_diff_by_isssuer,
@@ -344,7 +344,7 @@ def main():
                 log.info(f"Difference stash complete. sz={Path(args.diffPath).stat().st_size}"
                          + f"memory={psutil.virtual_memory()}")
             except Exception as e:
-                log.error(f"Failed to make a diff, proceeding without one: {e}",
+                log.error(f"Diff: Failed to make a diff, proceeding without one: {e}",
                           exc_info=sys.exc_info())
             sw.end('make diff')
 

--- a/create_filter_cascade/certs_to_crlite.py
+++ b/create_filter_cascade/certs_to_crlite.py
@@ -311,8 +311,7 @@ def main():
     if args.previd is not None:
         prior_folder = Path(args.certPath) / Path(args.previd)
         prior_revoked_path = prior_folder / Path("list-revoked.keys")
-        prior_valid_path = prior_folder / Path("list-valid.keys")
-        if not (prior_revoked_path.is_file() and prior_valid_path.is_file()):
+        if not prior_revoked_path.is_file():
             log.warning("Diff: Previous ID specified but no filter files found.")
         else:
             sw.start('make diff')
@@ -327,21 +326,11 @@ def main():
                     )
                     sw.end('diff revoked filter')
 
-                log.info("Diff: Making diff for known valid entries")
-                with open(prior_valid_path, "rb") as prior_fp, open(args.validKeys, "rb") as fp:
-                    sw.start('diff valid filter')
-                    nonrevoked_diff_by_issuer = find_additions(
-                        old_by_issuer=crlite.readFromCertListByIssuer(prior_fp),
-                        new_by_issuer=crlite.readFromCertListByIssuer(fp),
-                    )
-                    sw.end('diff valid filter')
-
                 log.info("Diff: Saving difference stash.")
                 crlite.save_additions(
                     out_path=args.diffPath,
-                    revoked_by_issuer=revoked_diff_by_isssuer,
-                    nonrevoked_by_issuer=nonrevoked_diff_by_issuer)
-                log.info(f"Difference stash complete. sz={Path(args.diffPath).stat().st_size}"
+                    revoked_by_issuer=revoked_diff_by_isssuer)
+                log.info(f"Difference stash complete. sz={Path(args.diffPath).stat().st_size} "
                          + f"memory={psutil.virtual_memory()}")
             except Exception as e:
                 log.error(f"Diff: Failed to make a diff, proceeding without one: {e}",

--- a/create_filter_cascade/crlite.py
+++ b/create_filter_cascade/crlite.py
@@ -139,7 +139,7 @@ def getCertList(certpath, issuer):
     if not os.path.isfile(certpath):
         raise Exception(f"getCertList: {certpath} not a file")
 
-    log.info(f"getCertList opening {Path(certpath)} (sz={Path(certpath).stat().st_size})")
+    log.debug(f"getCertList opening {Path(certpath)} (sz={Path(certpath).stat().st_size})")
 
     with open(certpath, "r") as f:
         try:

--- a/create_filter_cascade/read_keys.py
+++ b/create_filter_cascade/read_keys.py
@@ -34,6 +34,45 @@ def read_keys(path, emit=False):
     print(f"Issuer Lengths: {issuerLen.most_common(5)} Serial Lengths: {serialLen.most_common(5)}")
 
 
+def read_stash(path, emit=False):
+    cnt = Counter()
+    issuers = Counter()
+    revocations = Counter()
+    valid = Counter()
+    serialLen = Counter()
+
+    with open(path, "rb") as fp:
+        for data in crlite.readFromAdditionsList(fp):
+            cnt["issuers"] += 1
+
+            issuers[data["issuerId"]] += 1
+            revocations[data["issuerId"]] += len(data["revocations"])
+            valid[data["issuerId"]] += len(data["valid"])
+
+            cnt["revocations"] += len(data["revocations"])
+            cnt["valid"] += len(data["valid"])
+
+            for certId in data["revocations"]:
+                serialLen[len(certId.serial)] += 1
+            for certId in data["valid"]:
+                serialLen[len(certId.serial)] += 1
+
+            if emit:
+                print(f"{data['issuerId']} new revocations: {len(data['revocations'])}, "
+                      + f"new valids: {len(data['valid'])}")
+
+    print(f"Issuers Affected: {cnt['issuers']}")
+    print(f"Number of New Revocations: {cnt['revocations']}")
+    print(f"Number of New Valid: {cnt['valid']}")
+
+    totalBytes = 0
+    for l, qty in serialLen.items():
+        totalBytes += l * qty
+    print(f"Distribution of Serial Lengths: {serialLen.most_common(32)}")
+    print(f"Aggregated Serials in Bytes: {totalBytes} bytes")
+    print(f"Stash File Size in Bytes: {path.stat().st_size} bytes")
+
+
 def main():
     parser = argparse.ArgumentParser()
 
@@ -59,7 +98,7 @@ def main():
     if args.keys:
         read_keys(args.keys, emit=args.print)
     if args.stash:
-        raise Exception("not implemented")
+        read_stash(args.stash, emit=args.print)
 
 
 if __name__ == "__main__":

--- a/create_filter_cascade/read_keys.py
+++ b/create_filter_cascade/read_keys.py
@@ -38,7 +38,6 @@ def read_stash(path, emit=False):
     cnt = Counter()
     issuers = Counter()
     revocations = Counter()
-    valid = Counter()
     serialLen = Counter()
 
     with open(path, "rb") as fp:
@@ -47,23 +46,17 @@ def read_stash(path, emit=False):
 
             issuers[data["issuerId"]] += 1
             revocations[data["issuerId"]] += len(data["revocations"])
-            valid[data["issuerId"]] += len(data["valid"])
 
             cnt["revocations"] += len(data["revocations"])
-            cnt["valid"] += len(data["valid"])
 
             for certId in data["revocations"]:
                 serialLen[len(certId.serial)] += 1
-            for certId in data["valid"]:
-                serialLen[len(certId.serial)] += 1
 
             if emit:
-                print(f"{data['issuerId']} new revocations: {len(data['revocations'])}, "
-                      + f"new valids: {len(data['valid'])}")
+                print(f"{data['issuerId']} new revocations: {len(data['revocations'])}")
 
     print(f"Issuers Affected: {cnt['issuers']}")
     print(f"Number of New Revocations: {cnt['revocations']}")
-    print(f"Number of New Valid: {cnt['valid']}")
 
     totalBytes = 0
     for l, qty in serialLen.items():

--- a/create_filter_cascade/test.py
+++ b/create_filter_cascade/test.py
@@ -145,16 +145,15 @@ class TestCertLists(unittest.TestCase):
             self.assertCertListEqual(loaded_nonrevoked, nonrevoked)
 
     def test_save_diff_file(self):
-        revoked, nonrevoked = static_test_certs()
+        revoked, _ = static_test_certs()
 
         with tempfile.TemporaryDirectory() as tmpdirname:
             diff_path = tmpdirname / Path("diff.bin")
 
             crlite.save_additions(out_path=diff_path,
-                                  revoked_by_issuer=revoked,
-                                  nonrevoked_by_issuer=nonrevoked)
+                                  revoked_by_issuer=revoked)
 
-            self.assertEqual(diff_path.stat().st_size, 74)
+            self.assertEqual(diff_path.stat().st_size, 37)
 
     def test_make_diff_completely_different(self):
         old, new = static_test_certs()

--- a/workflow/4-generate_mlbf
+++ b/workflow/4-generate_mlbf
@@ -43,7 +43,7 @@ def main():
 
             workflow.download_from_google_cloud(bucket_name, f"{latest}/mlbf/list-revoked.keys",
                                                 dest / Path("list-revoked.keys"))
-            workflow.download_from_google_cloud(bucket_name, f"{latest}/mlbf/list-valid.key",
+            workflow.download_from_google_cloud(bucket_name, f"{latest}/mlbf/list-valid.keys",
                                                 dest / Path("list-valid.keys"))
 
             cmdline = cmdline + ["-previd", dest]


### PR DESCRIPTION
Follow-on integration fixes for the stash functionality from #48:

- Stashes need only contain new revocations. While one would need new additions and revocations to actually calculate a filter update, the stash is pre-filter: our verification algorithm becomes:
 
1. Is the issuer enrolled in CRLite? If not: OCSP
1. Is the certificate newer than our stash? If so: OCSP
1. Is the certificate included in the stash? If so: Revoked
1. Is the certificate newer than our CRLite filter? If so: Valid
1. Is the certificate included in the CRLite filter? If so: Revoked
1. Valid

- Add utility methods for reading stash files, and add those to `read_keys.py` for debugging
- Fix a typo in the `4-generate_mlbf` script