### PR TITLE
Don't bypass CRLs when there's an issue with the new download

### DIFF
--- a/go/cmd/aggregate-crls/aggregate-crls.go
+++ b/go/cmd/aggregate-crls/aggregate-crls.go
@@ -131,6 +131,10 @@ func (ae *AggregateEngine) crlFetchWorkerProcessOne(ctx context.Context, crlUrl 
 	if err != nil {
 		glog.Warningf("[%s] Could not download %s to %s: %s", issuer.ID(), crlUrl.String(),
 			tmpPath, err)
+		err = os.Remove(tmpPath)
+		if err != nil {
+			glog.Warningf("[%s] Failed to remove invalid tmp file %s: %s", issuer.ID(), tmpPath, err)
+		}
 	} else {
 		// Validate the file and move it to the finalPath
 		cert, err := ae.issuers.GetCertificateForIssuer(issuer)


### PR DESCRIPTION
`aggregate_crls` had code to download a CRL to a temporary location, verify it, and then copy it over the previous CRL if it looked good. However there was a `continue` in there that made the routine throw away the CRL's contents.

This reworks that part of the code to be more testable, and add tests!

Most notably, even if `crlFetchWorkerProcessOne` returns an error, it still might return a valid CRL on disk, which should then be used for processing.