### PR TITLE
Fix #76 - Don't suffix intermediate PEMs with .pem

### DIFF
--- a/moz_kinto_publisher/main.py
+++ b/moz_kinto_publisher/main.py
@@ -417,7 +417,7 @@ class Intermediate:
         rw_client.attach_file(
             collection=settings.KINTO_INTERMEDIATES_COLLECTION,
             fileContents=self.pemData,
-            fileName=f"{base64.urlsafe_b64encode(self.pubKeyHash).decode('utf-8')}.pem",
+            fileName=f"{base64.urlsafe_b64encode(self.pubKeyHash).decode('utf-8')}",
             mimeType="text/plain",
             recordId=kinto_id or self.kinto_id,
         )


### PR DESCRIPTION
This is safe to do as Firefox does not examine the filename at all: https://searchfox.org/mozilla-central/rev/5e6c7717255ca9638b2856c2b2058919aec1d21d/security/manager/ssl/RemoteSecuritySettings.jsm#623-646