### PR TITLE
Fix #59 - Make the staging branch automatically build images at Google Cloud Run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   python: circleci/python@0.2.1
+  gcp-cloud-run: circleci/gcp-cloud-run@1.0.2
 
 jobs:
   python-build-and-test:
@@ -69,8 +70,25 @@ jobs:
           command: go test -race -short ./...
           working_directory: /go/src/github.com/mozilla.com/crlite/go
 
+  build_gke:
+    docker:
+      - image: 'cimg/base:stable'
+    steps:
+      - checkout
+      - gcp-cloud-run/init
+      - gcp-cloud-run/build:
+          config: containers/cloudbuild.yaml
+
 workflows:
+  version: 2
   main:
     jobs:
       - python-build-and-test
       - golang-build-and-test
+      - build_gke:
+          filters:
+            branches:
+              only: /.*staging.*/
+          requires:
+            - python-build-and-test
+            - golang-build-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,7 @@ jobs:
       - gcp-cloud-run/init
       - gcp-cloud-run/build:
           config: containers/cloudbuild.yaml
+          args: --substitutions _CRLITE_TAG=${CIRCLE_BRANCH}
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,13 +114,13 @@ workflows:
       - build_gke:
           filters:
             branches:
-              only: /.*staging.*/
+              only: staging
           requires:
             - python-build-and-test
             - golang-build-and-test
       - deploy_gke:
           filters:
             branches:
-              only: /.*staging.*/
+              only: staging
           requires:
             - build_gke

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,8 @@ version: 2.1
 orbs:
   python: circleci/python@0.2.1
   gcp-cloud-run: circleci/gcp-cloud-run@1.0.2
+  gcp-gke: circleci/gcp-gke@1.0.4
+  kubernetes: circleci/kubernetes@0.11.0
 
 jobs:
   python-build-and-test:
@@ -78,7 +80,30 @@ jobs:
       - gcp-cloud-run/init
       - gcp-cloud-run/build:
           config: containers/cloudbuild.yaml
-          args: --substitutions _CRLITE_TAG=${CIRCLE_BRANCH}
+          args: --substitutions _CRLITE_TAG=${CIRCLE_SHA1}
+
+  deploy_gke:
+    docker:
+      - image: 'cimg/base:stable'
+    steps:
+      - gcp-gke/update-kubeconfig-with-credentials:
+          cluster: ${GKE_CLUSTER_ID}
+          install-kubectl: true
+          perform-login: true
+      - kubernetes/update-container-image:
+          container-image-updates: crlite-fetch=gcr.io/crlite-beta/crlite:${CIRCLE_SHA1}-fetch
+          resource-name: deployment/crlite-fetch
+          show-kubectl-command: true
+          get-rollout-status: true
+          watch-timeout: 5m
+      - kubernetes/update-container-image:
+          container-image-updates: crlite-generate=gcr.io/crlite-beta/crlite:${CIRCLE_SHA1}-generate
+          resource-name: cronjob/crlite-generate
+          show-kubectl-command: true
+      - kubernetes/update-container-image:
+          container-image-updates: crlite-publish=gcr.io/crlite-beta/crlite:${CIRCLE_SHA1}-publish
+          resource-name: cronjob/crlite-publish
+          show-kubectl-command: true
 
 workflows:
   version: 2
@@ -93,3 +118,9 @@ workflows:
           requires:
             - python-build-and-test
             - golang-build-and-test
+      - deploy_gke:
+          filters:
+            branches:
+              only: /.*staging.*/
+          requires:
+            - build_gke

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ The crlite-fetch container runs forever, fetching CT updates:
 docker run --rm -it \
   -e "FIRESTORE_EMULATOR_HOST=my_ip_address:8403" \
   -e "outputRefreshMs=1000" \
-  crlite:0.1-fetch
+  crlite:staging-fetch
 ```
 
 The crlite-generate container constructs a new filter. To use local disk, set the `certPath` to `/ctdata` and mount that volume in Docker. You should also mount the volume `/processing` to get the output files:
@@ -154,7 +154,7 @@ docker run --rm -it \
   -e "outputRefreshMs=1000" \
   --mount type=bind,src=/tmp/ctlite_data,dst=/ctdata \
   --mount type=bind,src=/tmp/crlite_results,dst=/processing \
-  crlite:0.1-generate
+  crlite:staging-generate
 ```
 
 See the [`test-via-docker.sh`](https://github.com/mozilla/crlite/blob/main/test-via-docker.sh) for an example.

--- a/containers/README.md
+++ b/containers/README.md
@@ -4,7 +4,7 @@ See `./build-local.sh`
 
 Basic build:
 ```
-docker build -t crlite:0.1 .. -f Dockerfile
+docker build -t crlite:staging .. -f Dockerfile
 ```
 
 To run the tools, you'll need Redis 4+:
@@ -20,7 +20,7 @@ Then you can execute the docker container, setting any environment vars you want
 docker run --rm -it \
   -e "redisHost=10.0.0.115:6379" \
   -e "outputRefreshMs=1000" \
-  crlite:0.1
+  crlite-fetch:staging
 ```
 
 See the Running section for more environment variables.

--- a/containers/build-gcp.sh
+++ b/containers/build-gcp.sh
@@ -1,4 +1,11 @@
 #!/bin/bash -xe
+TAG=testing
+
 cd $(dirname $0)
 gcloud config set project ${crlite_project:-crlite-beta}
-gcloud builds submit --config ./cloudbuild.yaml ..
+
+gcloud builds submit --config ./cloudbuild.yaml --substitutions _CRLITE_TAG=${TAG} ..
+
+kubectl set image deployment/crlite-fetch crlite-fetch=gcr.io/crlite-beta/crlite:${TAG}-fetch
+kubectl set image cronjob/crlite-generate crlite-generate=gcr.io/crlite-beta/crlite:${TAG}-generate
+kubectl set image cronjob/crlite-publish crlite-publish=gcr.io/crlite-beta/crlite:${TAG}-publish

--- a/containers/build-gcp.sh
+++ b/containers/build-gcp.sh
@@ -6,6 +6,9 @@ gcloud config set project ${crlite_project:-crlite-beta}
 
 gcloud builds submit --config ./cloudbuild.yaml --substitutions _CRLITE_TAG=${TAG} ..
 
+echo "Deploying ${TAG}. ctrl-c to halt."
+read x
+
 kubectl set image deployment/crlite-fetch crlite-fetch=gcr.io/crlite-beta/crlite:${TAG}-fetch
 kubectl set image cronjob/crlite-generate crlite-generate=gcr.io/crlite-beta/crlite:${TAG}-generate
 kubectl set image cronjob/crlite-publish crlite-publish=gcr.io/crlite-beta/crlite:${TAG}-publish

--- a/containers/build-local.sh
+++ b/containers/build-local.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -xe
 
-VER=0.1
+VER=staging
 CT_MAPREDUCE_VER=v1.0.6
 
 docker build -t crlite:${VER} .. -f Dockerfile --build-arg ct_mapreduce_ver=${CT_MAPREDUCE_VER}

--- a/containers/cloudbuild.yaml
+++ b/containers/cloudbuild.yaml
@@ -1,34 +1,34 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/crlite:${_CRLITE_VERSION}', '.',
+  args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/crlite:${_CRLITE_TAG}', '.',
           '-f', './containers/Dockerfile',
           '--build-arg', 'ct_mapreduce_ver=${_CT_MAPREDUCE_VERSION}' ]
   id: 'crlite'
 
 - name: 'gcr.io/cloud-builders/docker'
-  args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/crlite:${_CRLITE_VERSION}-fetch', '.',
+  args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/crlite:${_CRLITE_TAG}-fetch', '.',
           '-f', './containers/crlite-fetch/Dockerfile',
-          '--build-arg', 'crlite_image=gcr.io/$PROJECT_ID/crlite:${_CRLITE_VERSION}' ]
+          '--build-arg', 'crlite_image=gcr.io/$PROJECT_ID/crlite:${_CRLITE_TAG}' ]
   wait_for: ['crlite']
 
 - name: 'gcr.io/cloud-builders/docker'
-  args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/crlite:${_CRLITE_VERSION}-generate', '.',
+  args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/crlite:${_CRLITE_TAG}-generate', '.',
           '-f', './containers/crlite-generate/Dockerfile',
-          '--build-arg', 'crlite_image=gcr.io/$PROJECT_ID/crlite:${_CRLITE_VERSION}' ]
+          '--build-arg', 'crlite_image=gcr.io/$PROJECT_ID/crlite:${_CRLITE_TAG}' ]
   wait_for: ['crlite']
 
 - name: 'gcr.io/cloud-builders/docker'
-  args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/crlite:${_CRLITE_VERSION}-publish', '.',
+  args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/crlite:${_CRLITE_TAG}-publish', '.',
           '-f', './containers/crlite-publish/Dockerfile',
-          '--build-arg', 'crlite_image=gcr.io/$PROJECT_ID/crlite:${_CRLITE_VERSION}' ]
+          '--build-arg', 'crlite_image=gcr.io/$PROJECT_ID/crlite:${_CRLITE_TAG}' ]
   wait_for: ['crlite']
 
 substitutions:
-    _CRLITE_VERSION: "0.1"
+    _CRLITE_TAG: "testing"
     _CT_MAPREDUCE_VERSION: "v1.0.6"
 
 images:
-- 'gcr.io/$PROJECT_ID/crlite:${_CRLITE_VERSION}'
-- 'gcr.io/$PROJECT_ID/crlite:${_CRLITE_VERSION}-fetch'
-- 'gcr.io/$PROJECT_ID/crlite:${_CRLITE_VERSION}-generate'
-- 'gcr.io/$PROJECT_ID/crlite:${_CRLITE_VERSION}-publish'
+- 'gcr.io/$PROJECT_ID/crlite:${_CRLITE_TAG}'
+- 'gcr.io/$PROJECT_ID/crlite:${_CRLITE_TAG}-fetch'
+- 'gcr.io/$PROJECT_ID/crlite:${_CRLITE_TAG}-generate'
+- 'gcr.io/$PROJECT_ID/crlite:${_CRLITE_TAG}-publish'

--- a/containers/cloudbuild.yaml
+++ b/containers/cloudbuild.yaml
@@ -24,7 +24,7 @@ steps:
   wait_for: ['crlite']
 
 substitutions:
-    _CRLITE_TAG: "testing"
+    _CRLITE_TAG: "staging"
     _CT_MAPREDUCE_VERSION: "v1.0.6"
 
 images:

--- a/containers/crlite-fetch/pod.yaml
+++ b/containers/crlite-fetch/pod.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: crlite-fetch
-        image: gcr.io/crlite-beta/crlite:0.1-fetch
+        image: gcr.io/crlite-beta/crlite:staging-fetch
         envFrom:
         - configMapRef:
             name: crlite-config

--- a/containers/crlite-generate/pod.yaml
+++ b/containers/crlite-generate/pod.yaml
@@ -27,7 +27,7 @@ spec:
             envFrom:
             - configMapRef:
                 name: crlite-config
-            image: gcr.io/crlite-beta/crlite:0.1-generate
+            image: gcr.io/crlite-beta/crlite:staging-generate
             imagePullPolicy: Always
             resources:
               requests:

--- a/containers/crlite-publish/pod.yaml
+++ b/containers/crlite-publish/pod.yaml
@@ -20,7 +20,7 @@ spec:
             envFrom:
             - configMapRef:
                 name: crlite-config
-            image: gcr.io/crlite-beta/crlite:0.1-publish
+            image: gcr.io/crlite-beta/crlite:staging-publish
             imagePullPolicy: Always
             terminationMessagePath: /dev/termination-log
             terminationMessagePolicy: FallbackToLogsOnError

--- a/test-via-docker.sh
+++ b/test-via-docker.sh
@@ -33,7 +33,7 @@ docker run --rm -it \
   -e "logList=https://ct.googleapis.com/logs/argon2021/, https://ct.googleapis.com/logs/argon2022/, https://ct.googleapis.com/logs/argon2023/" \
   -e "limit=500" \
   -e "runForever=false" \
-  crlite:0.1-fetch
+  crlite:staging-fetch
 
 docker run --rm -it \
   -e "redisHost=${my_ip}:6379" \
@@ -42,11 +42,11 @@ docker run --rm -it \
   -e "outputRefreshMs=1000" \
   --mount type=bind,src=/tmp/crlite/persistent,dst=/persistent \
   --mount type=bind,src=/tmp/crlite/processing,dst=/processing \
-  crlite:0.1-generate
+  crlite:staging-generate
 
 docker run --rm -it \
   -e "redisHost=${my_ip}:6379" \
   -e "credentials_data=$(base64 ${GOOGLE_APPLICATION_CREDENTIALS})" \
   -e "DoNotUpload=true" \
   -e "outputRefreshMs=1000" \
-  crlite:0.1-publish
+  crlite:staging-publish


### PR DESCRIPTION
This patchset builds Docker images named after the sha1 ID of Git revisions pushed to the `staging` branch in Google Cloud Build, then deploys those to the `crlite-beta` Kubernetes cluster.