### PR TITLE
Revert "Fix #76 - Don't suffix intermediate PEMs with .pem"

### DIFF
--- a/moz_kinto_publisher/main.py
+++ b/moz_kinto_publisher/main.py
@@ -417,7 +417,7 @@ class Intermediate:
         rw_client.attach_file(
             collection=settings.KINTO_INTERMEDIATES_COLLECTION,
             fileContents=self.pemData,
-            fileName=f"{base64.urlsafe_b64encode(self.pubKeyHash).decode('utf-8')}",
+            fileName=f"{base64.urlsafe_b64encode(self.pubKeyHash).decode('utf-8')}.pem",
             mimeType="text/plain",
             recordId=kinto_id or self.kinto_id,
         )


### PR DESCRIPTION
Reverts mozilla/crlite#82 per https://bugzilla.mozilla.org/show_bug.cgi?id=1644298#c8