### PR TITLE
Expose and use a health/liveness check for the ct-fetch deployment

### DIFF
--- a/containers/build-local.sh
+++ b/containers/build-local.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -xe
 
 VER=staging
-CT_MAPREDUCE_VER=v1.0.6
+CT_MAPREDUCE_VER=v1.0.7
 
 docker build -t crlite:${VER} .. -f Dockerfile --build-arg ct_mapreduce_ver=${CT_MAPREDUCE_VER}
 docker build -t crlite:${VER}-fetch .. -f crlite-fetch/Dockerfile --build-arg crlite_image=crlite:${VER}

--- a/containers/build-local.sh
+++ b/containers/build-local.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -xe
 
 VER=staging
-CT_MAPREDUCE_VER=v1.0.7
+CT_MAPREDUCE_VER=v1.0.8
 
 docker build -t crlite:${VER} .. -f Dockerfile --build-arg ct_mapreduce_ver=${CT_MAPREDUCE_VER}
 docker build -t crlite:${VER}-fetch .. -f crlite-fetch/Dockerfile --build-arg crlite_image=crlite:${VER}

--- a/containers/cloudbuild.yaml
+++ b/containers/cloudbuild.yaml
@@ -25,7 +25,7 @@ steps:
 
 substitutions:
     _CRLITE_TAG: "staging"
-    _CT_MAPREDUCE_VERSION: "v1.0.6"
+    _CT_MAPREDUCE_VERSION: "v1.0.7"
 
 images:
 - 'gcr.io/$PROJECT_ID/crlite:${_CRLITE_TAG}'

--- a/containers/cloudbuild.yaml
+++ b/containers/cloudbuild.yaml
@@ -25,7 +25,7 @@ steps:
 
 substitutions:
     _CRLITE_TAG: "staging"
-    _CT_MAPREDUCE_VERSION: "v1.0.7"
+    _CT_MAPREDUCE_VERSION: "v1.0.8"
 
 images:
 - 'gcr.io/$PROJECT_ID/crlite:${_CRLITE_TAG}'

--- a/containers/crlite-config.properties.example
+++ b/containers/crlite-config.properties.example
@@ -15,9 +15,13 @@ numThreads=16
 runForever=true
 outputRefreshPeriod=90s
 statsRefreshPeriod=5m
-savePeriod=30s
 pollingDelayMean=60m
 pollingDelayStdDev=10
+
+# The save period needs to be coordinated with the ct-fetch pod liveness probe,
+# as liveness health information won't be available until the first save.
+# The actual save period is this + a few seconds of jitter calculated in ct-fetch
+savePeriod=30s
 healthAddr=:8080
 
 # Set true if you want to report to Stackdriver and provide the relevant project ID

--- a/containers/crlite-config.properties.example
+++ b/containers/crlite-config.properties.example
@@ -15,9 +15,10 @@ numThreads=16
 runForever=true
 outputRefreshPeriod=90s
 statsRefreshPeriod=5m
-savePeriod=5m
+savePeriod=30s
 pollingDelayMean=60m
 pollingDelayStdDev=10
+healthAddr=:8080
 
 # Set true if you want to report to Stackdriver and provide the relevant project ID
 #stackdriverMetrics=true

--- a/containers/crlite-fetch/Dockerfile
+++ b/containers/crlite-fetch/Dockerfile
@@ -7,3 +7,5 @@ CMD [ "/bin/bash", "-xc", "/app/crlite-fetch.sh" ]
 ENV runForever true
 ENV logExpiredEntries false
 ENV logList https://ct.googleapis.com/icarus
+
+EXPOSE 8080/tcp

--- a/containers/crlite-fetch/pod.yaml
+++ b/containers/crlite-fetch/pod.yaml
@@ -31,6 +31,12 @@ spec:
         - configMapRef:
             name: crlite-config
         imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 60
+          periodSeconds: 60
         resources:
           requests:
             cpu: 1

--- a/containers/crlite-fetch/pod.yaml
+++ b/containers/crlite-fetch/pod.yaml
@@ -31,10 +31,14 @@ spec:
         - configMapRef:
             name: crlite-config
         imagePullPolicy: Always
+        ports:
+        - name: liveness-port
+          containerPort: 8080
+          hostPort: 8080
         livenessProbe:
           httpGet:
             path: /health
-            port: 8080
+            port: liveness-port
           initialDelaySeconds: 60
           periodSeconds: 60
         resources:

--- a/go/go.mod
+++ b/go/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/go-immutable-radix v1.1.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.1 // indirect
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
-	github.com/jcjones/ct-mapreduce v1.0.7
+	github.com/jcjones/ct-mapreduce v1.0.8
 	github.com/smartystreets/assertions v1.0.1 // indirect
 	github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337 // indirect
 	github.com/vbauerster/mpb/v5 v5.0.3

--- a/go/go.mod
+++ b/go/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/go-immutable-radix v1.1.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.1 // indirect
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
-	github.com/jcjones/ct-mapreduce v1.0.6
+	github.com/jcjones/ct-mapreduce v1.0.7
 	github.com/smartystreets/assertions v1.0.1 // indirect
 	github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337 // indirect
 	github.com/vbauerster/mpb/v5 v5.0.3

--- a/go/go.sum
+++ b/go/go.sum
@@ -171,8 +171,8 @@ github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/jcjones/ct-mapreduce v1.0.6 h1:lRN1596WWvD6ZVrJ8K5Dyl7LXObYH2PEORDytCxAEnM=
-github.com/jcjones/ct-mapreduce v1.0.6/go.mod h1:pY6zH4CWcXxGDVGPkw1Cj3kXzSx+OF56T7DF/H0eLW8=
+github.com/jcjones/ct-mapreduce v1.0.7 h1:suih8e/6gF6SrC239izPalvhgLASqd8Ub/GiOXQcrKs=
+github.com/jcjones/ct-mapreduce v1.0.7/go.mod h1:pY6zH4CWcXxGDVGPkw1Cj3kXzSx+OF56T7DF/H0eLW8=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=

--- a/go/go.sum
+++ b/go/go.sum
@@ -171,8 +171,8 @@ github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/jcjones/ct-mapreduce v1.0.7 h1:suih8e/6gF6SrC239izPalvhgLASqd8Ub/GiOXQcrKs=
-github.com/jcjones/ct-mapreduce v1.0.7/go.mod h1:pY6zH4CWcXxGDVGPkw1Cj3kXzSx+OF56T7DF/H0eLW8=
+github.com/jcjones/ct-mapreduce v1.0.8 h1:UCihCqEVq3xMEOT7wxtMPYUJtXBbxCEw1gbnBAarQ7M=
+github.com/jcjones/ct-mapreduce v1.0.8/go.mod h1:pY6zH4CWcXxGDVGPkw1Cj3kXzSx+OF56T7DF/H0eLW8=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=

--- a/test-via-docker.sh
+++ b/test-via-docker.sh
@@ -25,7 +25,7 @@ fi
 
 echo "Ensure Redis is running at ${my_ip}:6379"
 
-docker run --rm -it -P \
+docker run --rm -it -p 8080:8080/tcp \
   -e "redisHost=${my_ip}:6379" \
   -e "credentials_data=$(base64 ${GOOGLE_APPLICATION_CREDENTIALS})" \
   -e "DoNotUpload=true" \

--- a/test-via-docker.sh
+++ b/test-via-docker.sh
@@ -25,7 +25,7 @@ fi
 
 echo "Ensure Redis is running at ${my_ip}:6379"
 
-docker run --rm -it \
+docker run --rm -it -P \
   -e "redisHost=${my_ip}:6379" \
   -e "credentials_data=$(base64 ${GOOGLE_APPLICATION_CREDENTIALS})" \
   -e "DoNotUpload=true" \


### PR DESCRIPTION
Resolve #55. `ct-fetch` should have a Kubernetes endpoint that can verify liveness. `ct-mapreduce` added that in v0.1.7 (https://github.com/jcjones/ct-mapreduce/pull/41), and this PR wires up that health check to Kubernetes.