### PR TITLE
Coordinate the Publisher with Upload Artifacts to Storage script

### DIFF
--- a/workflow/2-upload_artifacts_to_storage
+++ b/workflow/2-upload_artifacts_to_storage
@@ -2,6 +2,7 @@
 
 from google.cloud import storage
 from pathlib import Path
+from datetime import datetime
 
 import argparse
 import os
@@ -86,6 +87,11 @@ def main():
     for path, dirs, files in os.walk(idPath / "mlbf"):
         remoteFolder = Path("latest")
         uploadFiles(files, Path(path), remoteFolder, bucket, args=args)
+
+    sentinel = bucket.blob(str(Path(idPath.name) / "completed"))
+    log.info(f"Saving 'completed' marker to {sentinel.name}")
+    if not args.noop:
+        sentinel.upload_from_string(f"Upload completed at {datetime.utcnow()}")
 
 
 if __name__ == "__main__":

--- a/workflow/2-upload_artifacts_to_storage
+++ b/workflow/2-upload_artifacts_to_storage
@@ -48,8 +48,8 @@ def uploadFiles(files, localFolder, remoteFolder, bucket, *, args):
         blob.upload_from_filename(str(localFilePath))
 
 
-def ensureFileOrAbort(idPath, path):
-    filePath = idPath / Path(path)
+def ensureFileOrAbort(runIdPath, path):
+    filePath = runIdPath / Path(path)
     if not filePath.exists():
         log.error(f"{filePath} does not exist, aborting.")
         sys.exit(1)
@@ -65,13 +65,13 @@ def main():
     storage_client = storage.Client()
     bucket = storage_client.get_bucket(args.filter_bucket)
 
-    idPath = args.results_path[0].resolve()
+    runIdPath = args.results_path[0].resolve()
 
-    ensureFileOrAbort(idPath, Path("mlbf/filter"))
+    ensureFileOrAbort(runIdPath, Path("mlbf/filter"))
 
-    for path, dirs, files in os.walk(idPath):
+    for path, dirs, files in os.walk(runIdPath):
         localFolder = Path(path)
-        remoteFolder = localFolder.relative_to(idPath.parent)
+        remoteFolder = localFolder.relative_to(runIdPath.parent)
 
         uploadFiles(files, localFolder, remoteFolder, bucket, args=args)
 
@@ -80,15 +80,17 @@ def main():
             localPath, remotePath = extraString.split(":")
             for path, dirs, files in os.walk(localPath):
                 remoteFolder = (
-                    Path(idPath.name) / remotePath / Path(path).relative_to(localPath)
+                    Path(runIdPath.name)
+                    / remotePath
+                    / Path(path).relative_to(localPath)
                 )
                 uploadFiles(files, Path(path), remoteFolder, bucket, args=args)
 
-    for path, dirs, files in os.walk(idPath / "mlbf"):
+    for path, dirs, files in os.walk(runIdPath / "mlbf"):
         remoteFolder = Path("latest")
         uploadFiles(files, Path(path), remoteFolder, bucket, args=args)
 
-    sentinel = bucket.blob(str(Path(idPath.name) / "completed"))
+    sentinel = bucket.blob(str(Path(runIdPath.name) / "completed"))
     log.info(f"Saving 'completed' marker to {sentinel.name}")
     if not args.noop:
         sentinel.upload_from_string(f"Upload completed at {datetime.utcnow()}")


### PR DESCRIPTION
The `workflow/2-upload_artifacts_to_storage` script now uploads a file
`{run_folder}/completed` at completion time, which `moz_kinto_publisher`
watches for (for 5 minutes) before proceeding with uploading CRLite.

I didn't apply this logic to the intermediates because I don't see a similar
chicken-and-egg issue there. It'd fail gracefully.

Fixes #75

In staging e485e61