### PR TITLE
Expose StatsD Metrics

### DIFF
--- a/containers/build-local.sh
+++ b/containers/build-local.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -xe
 
 VER=staging
-CT_MAPREDUCE_VER=v1.0.8
+CT_MAPREDUCE_VER=v1.0.10
 
 docker build -t crlite:${VER} .. -f Dockerfile --build-arg ct_mapreduce_ver=${CT_MAPREDUCE_VER}
 docker build -t crlite:${VER}-fetch .. -f crlite-fetch/Dockerfile --build-arg crlite_image=crlite:${VER}

--- a/create_filter_cascade/certs_to_crlite.py
+++ b/create_filter_cascade/certs_to_crlite.py
@@ -321,8 +321,10 @@ def saveStats(args, stats):
 @metrics.timer("Main")
 def main():
     args = parseArgs(sys.argv[1:])
-    log = logging.getLogger("cert_to_crlite")
-    log.debug(args)
+    log.debug(f"certs_to_crlite called with arguments: {args}")
+    log.info(
+        f"StatsD information submitting to {metrics._addr} with prefix {metrics._prefix}."
+    )
 
     stats = {}
     known_nonrevoked_certs_len = None

--- a/create_filter_cascade/certs_to_crlite.py
+++ b/create_filter_cascade/certs_to_crlite.py
@@ -101,6 +101,7 @@ def createCertLists(
                 f"createCertLists Processing issuerObj={issuerObj}, "
                 + f"memory={psutil.virtual_memory()}"
             )
+            metrics.gauge("CreateCertLists.VirtualMemory", psutil.virtual_memory(), 1)
 
             issuer = issuerObj.issuer
             initIssuerStats(stats, issuer)
@@ -127,6 +128,12 @@ def createCertLists(
             log.debug(
                 f"createCertLists issuerObj={issuerObj} KNR={known_nonrevoked_certs_len} "
                 + f"KR={known_revoked_certs_len}"
+            )
+
+            metrics.incr("CreateCertLists.Issuers")
+            metrics.incr("CreateCertLists.KnownRevoked", count=known_revoked_certs_len)
+            metrics.incr(
+                "CreateCertLists.KnownNotRevoked", count=known_nonrevoked_certs_len
             )
 
     # TODO: Verify any revoked issuers that had no known issuers
@@ -171,6 +178,8 @@ def generateMLBF(args, stats, *, revoked_certs, nonrevoked_certs, nonrevoked_cer
             layers=cascade.layerCount(), bits=cascade.bitCount()
         )
     )
+    metrics.gauge("GenerateMLBF.BitCount", cascade.bitCount())
+    metrics.gauge("GenerateMLBF.LayerCount", cascade.layerCount())
     return cascade
 
 

--- a/create_filter_cascade/setup.py
+++ b/create_filter_cascade/setup.py
@@ -16,7 +16,7 @@ setup(
     author="J.C. Jones",
     author_email="jc@mozilla.com",
     license="Mozilla Public License 2.0 (MPL 2.0)",
-    install_requires=["psutil", "dbx-stopwatch", "filtercascade"],
+    install_requires=["filtercascade", "psutil", "statsd"],
     include_package_data=True,
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ setup(
     install_requires=[
         "bsdiff4>=1.1",
         "cryptography>=2.2",
-        "dbx-stopwatch>=1.5",
         "Deprecated >= 1.2",
         "filtercascade>=0.3.1",
         "glog>=0.3",
@@ -19,5 +18,6 @@ setup(
         "pyOpenSSL>=17.5",
         "python-decouple>=3.1",
         "requests[socks]>=2.10.0",
+        "statsd>=3.3",
     ],
 )


### PR DESCRIPTION
Fixes #56. 

This adds new env variables, `statsdHost` and `statsdPort`, to the Go and Python scripts, revealing a variety of timers, gauges, and incrementing counters.

As of now, these are the metrics, as obtained via graphite's `/metrics/index.json` endpoint:

```
stats.create_filter_cascade.CreateCertLists.Issuers
stats.create_filter_cascade.CreateCertLists.KnownNotRevoked
stats.create_filter_cascade.CreateCertLists.KnownRevoked
stats.ct-fetch.insertCTWorker.Inserted
stats.gauges.create_filter_cascade.CreateCertLists.VirtualMemory.available
stats.gauges.create_filter_cascade.GenerateMLBF.BitCount
stats.gauges.create_filter_cascade.GenerateMLBF.LayerCount
stats.timers.aggregate-crls.KeysToChan
stats.timers.aggregate-crls.List
stats.timers.aggregate-known.KeysToChan
stats.timers.aggregate-known.SetToChan
stats.timers.create_filter_cascade.CreateCertLists
stats.timers.create_filter_cascade.FindAdditions
stats.timers.create_filter_cascade.GenerateMLBF
stats.timers.create_filter_cascade.LoadRevokedCerts
stats.timers.create_filter_cascade.Main
stats.timers.create_filter_cascade.SaveAdditions
stats.timers.create_filter_cascade.SaveMLBF
stats.timers.create_filter_cascade.VerifyMLBF
stats.timers.ct-fetch.ExpireAt
stats.timers.ct-fetch.insertCTWorker.ParseCertificates
stats.timers.ct-fetch.insertCTWorker.Store
stats.timers.ct-fetch.LogWorker.GetRawEntries
stats.timers.ct-fetch.LogWorker.LogEntryFromLeaf
stats.timers.ct-fetch.LogWorker.ProcessedEntry
stats.timers.ct-fetch.LogWorker.saveState
stats.timers.ct-fetch.LogWorker.SubmittedToChannel
stats.timers.ct-fetch.SetInsert
stats_counts.create_filter_cascade.CreateCertLists.Issuers
stats_counts.create_filter_cascade.CreateCertLists.KnownNotRevoked
stats_counts.create_filter_cascade.CreateCertLists.KnownRevoked
stats_counts.ct-fetch.certIsFilteredOut.expired
```

Could definitely do with a pass to normalize the naming.