### PR TITLE
Use docker.io's latest image as the defaults for the pods

### DIFF
--- a/containers/crlite-fetch/pod.yaml
+++ b/containers/crlite-fetch/pod.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: crlite-fetch
-        image: gcr.io/crlite-beta/crlite:staging-fetch
+        image: docker.io/mozilla/crlite:latest-fetch
         envFrom:
         - configMapRef:
             name: crlite-config

--- a/containers/crlite-generate/pod.yaml
+++ b/containers/crlite-generate/pod.yaml
@@ -27,7 +27,7 @@ spec:
             envFrom:
             - configMapRef:
                 name: crlite-config
-            image: gcr.io/crlite-beta/crlite:staging-generate
+            image: docker.io/mozilla/crlite:latest-generate
             imagePullPolicy: Always
             resources:
               requests:

--- a/containers/crlite-publish/pod.yaml
+++ b/containers/crlite-publish/pod.yaml
@@ -22,7 +22,7 @@ spec:
                 name: crlite-config
             - configMapRef:
                 name: crlite-publish-config
-            image: gcr.io/crlite-beta/crlite:staging-publish
+            image: docker.io/mozilla/crlite:latest-publish
             imagePullPolicy: Always
             terminationMessagePath: /dev/termination-log
             terminationMessagePolicy: FallbackToLogsOnError

--- a/containers/crlite-signoff/pod.yaml
+++ b/containers/crlite-signoff/pod.yaml
@@ -23,7 +23,7 @@ spec:
             - configMapRef:
                 name: crlite-signoff-config
 
-            image: gcr.io/crlite-beta/crlite:0.1-signoff
+            image: docker.io/mozilla/crlite:latest-signoff
             imagePullPolicy: Always
             terminationMessagePath: /dev/termination-log
             terminationMessagePolicy: FallbackToLogsOnError


### PR DESCRIPTION
This will hopefully be mostly obviated by collapsing the pods together, but even then they'll need to be using the crlite docker.io image...