### PR TITLE
Don't require credentials for ct-fetch

### DIFF
--- a/containers/crlite-fetch/crlite-fetch.sh
+++ b/containers/crlite-fetch/crlite-fetch.sh
@@ -1,11 +1,5 @@
 #!/bin/bash -e
 
-workflow=${crlite_workflow:-~/go/src/github.com/mozilla/crlite/workflow}
-
-source ${workflow}/0-set_credentials.inc
-
-echo "Expect ${outputRefreshPeriod} lag for initial output."
-
 ${crlite_bin:-~/go/bin}/ct-fetch -nobars -logtostderr -stderrthreshold=INFO
 
 exit 0


### PR DESCRIPTION
Fix #97 by not requiring any GCP service credentials for `ct-fetch`, since without Firestore none are needed.