### PR TITLE
 Split "Failed Verify" into more useful audit entries

### DIFF
--- a/go/cmd/aggregate-crls/aggregate-crls.go
+++ b/go/cmd/aggregate-crls/aggregate-crls.go
@@ -148,10 +148,10 @@ func (ae *AggregateEngine) crlFetchWorkerProcessOne(ctx context.Context, crlUrl 
 			glog.Fatalf("[%s] Could not find certificate for issuer: %s", issuer.ID(), err)
 		}
 
-		_, err = verifyCRL(tmpPath, cert, finalPath)
+		_, err = ae.verifyCRL(issuer, dlAuditor, &crlUrl, tmpPath, cert, finalPath)
 		if err != nil {
 			glog.Warningf("[%s] Failed to verify, keeping existing: %s", issuer.ID(), err)
-			ae.auditor.FailedVerifyUrl(issuer, &crlUrl, dlAuditor, err)
+			// Auditor had its methods called by verifyCRL
 			err = os.Remove(tmpPath)
 			if err != nil {
 				glog.Warningf("[%s] Failed to remove invalid tmp file %s: %s", issuer.ID(), tmpPath, err)
@@ -241,27 +241,31 @@ func loadAndCheckSignatureOfCRL(aPath string, aIssuerCert *x509.Certificate) (*p
 	return crl, err
 }
 
-func verifyCRL(aPath string, aIssuerCert *x509.Certificate, aPreviousPath string) (*pkix.CertificateList, error) {
-	glog.V(1).Infof("[%s] Verifying CRL", aPath)
+func (ae *AggregateEngine) verifyCRL(aIssuer storage.Issuer, dlAuditor *DownloadAuditor, crlUrl *url.URL, aPath string, aIssuerCert *x509.Certificate, aPreviousPath string) (*pkix.CertificateList, error) {
+	glog.V(1).Infof("[%s] Verifying CRL from URL %s", aPath, crlUrl)
 
 	crl, err := loadAndCheckSignatureOfCRL(aPath, aIssuerCert)
 	if err != nil {
+		ae.auditor.FailedVerifyUrl(aIssuer, crlUrl, dlAuditor, err)
 		return nil, err
 	}
 
 	if _, err = os.Stat(aPreviousPath); err == nil {
 		previousCrl, err := loadAndCheckSignatureOfCRL(aPreviousPath, aIssuerCert)
 		if err != nil {
+			ae.auditor.FailedVerifyPath(aIssuer, aPreviousPath, err)
 			return nil, err
 		}
 
 		if previousCrl.TBSCertList.ThisUpdate.After(crl.TBSCertList.ThisUpdate) {
+			ae.auditor.FailedOlderthanPrevious(aIssuer, crlUrl, dlAuditor, previousCrl.TBSCertList.ThisUpdate, crl.TBSCertList.ThisUpdate)
 			return previousCrl, fmt.Errorf("[%s] CRL is older than the previous CRL (previous=%s, this=%s)",
 				aPath, previousCrl.TBSCertList.ThisUpdate, crl.TBSCertList.ThisUpdate)
 		}
 	}
 
 	if crl.HasExpired(time.Now()) {
+		ae.auditor.Expired(aIssuer, crlUrl, crl.TBSCertList.NextUpdate)
 		glog.Warningf("[%s] CRL is expired, but proceeding anyway. (ThisUpdate=%s,"+
 			" NextUpdate=%s)", aPath, crl.TBSCertList.ThisUpdate, crl.TBSCertList.NextUpdate)
 	}
@@ -304,7 +308,7 @@ func (ae *AggregateEngine) aggregateCRLWorker(ctx context.Context, wg *sync.Wait
 			case <-ctx.Done():
 				return
 			default:
-				crl, err := verifyCRL(crlPath, cert, "")
+				crl, err := loadAndCheckSignatureOfCRL(crlPath, cert)
 				if err != nil {
 					ae.auditor.FailedVerifyPath(tuple.Issuer, crlPath, err)
 					glog.Errorf("[%s] Failed to verify: %s", crlPath, err)

--- a/go/cmd/aggregate-crls/aggregate-crls.go
+++ b/go/cmd/aggregate-crls/aggregate-crls.go
@@ -258,7 +258,7 @@ func (ae *AggregateEngine) verifyCRL(aIssuer storage.Issuer, dlAuditor *Download
 		}
 
 		if previousCrl.TBSCertList.ThisUpdate.After(crl.TBSCertList.ThisUpdate) {
-			ae.auditor.FailedOlderthanPrevious(aIssuer, crlUrl, dlAuditor, previousCrl.TBSCertList.ThisUpdate, crl.TBSCertList.ThisUpdate)
+			ae.auditor.FailedOlderThanPrevious(aIssuer, crlUrl, dlAuditor, previousCrl.TBSCertList.ThisUpdate, crl.TBSCertList.ThisUpdate)
 			return previousCrl, fmt.Errorf("[%s] CRL is older than the previous CRL (previous=%s, this=%s)",
 				aPath, previousCrl.TBSCertList.ThisUpdate, crl.TBSCertList.ThisUpdate)
 		}

--- a/go/cmd/aggregate-crls/crl-auditor.go
+++ b/go/cmd/aggregate-crls/crl-auditor.go
@@ -101,7 +101,7 @@ func (auditor *CrlAuditor) FailedVerifyUrl(issuer storage.Issuer, crlUrl *url.UR
 	})
 }
 
-func (auditor *CrlAuditor) FailedOlderthanPrevious(issuer storage.Issuer, crlUrl *url.URL, dlAuditor *DownloadAuditor, previous time.Time, this time.Time) {
+func (auditor *CrlAuditor) FailedOlderThanPrevious(issuer storage.Issuer, crlUrl *url.URL, dlAuditor *DownloadAuditor, previous time.Time, this time.Time) {
 	auditor.mutex.Lock()
 	defer auditor.mutex.Unlock()
 

--- a/go/cmd/aggregate-crls/crl-auditor.go
+++ b/go/cmd/aggregate-crls/crl-auditor.go
@@ -105,7 +105,7 @@ func (auditor *CrlAuditor) FailedOlderthanPrevious(issuer storage.Issuer, crlUrl
 	auditor.mutex.Lock()
 	defer auditor.mutex.Unlock()
 
-	err := fmt.Sprintf("Previous: %s, New: %s", previous, this)
+	err := fmt.Sprintf("Previous: %s, This Run: %s", previous, this)
 
 	auditor.Entries = append(auditor.Entries, CrlAuditEntry{
 		Timestamp:     time.Now().UTC(),

--- a/go/cmd/aggregate-crls/crl-auditor_test.go
+++ b/go/cmd/aggregate-crls/crl-auditor_test.go
@@ -200,7 +200,7 @@ func Test_FailedOld(t *testing.T) {
 	assertEntryUrlAndIssuer(t, ent, issuer, url)
 }
 
-func Test_FailedOlderthanPrevious(t *testing.T) {
+func Test_FailedOlderThanPrevious(t *testing.T) {
 	issuersObj := rootprogram.NewMozillaIssuers()
 	auditor := NewCrlAuditor(issuersObj)
 	issuer := issuersObj.NewTestIssuerFromSubjectString("Test Corporation SA")
@@ -208,7 +208,7 @@ func Test_FailedOlderthanPrevious(t *testing.T) {
 
 	assertEmptyList(t, auditor)
 
-	auditor.FailedOlderthanPrevious(issuer, url, NewDownloadAuditor(), time.Now(), time.Now().AddDate(0, 0, -1))
+	auditor.FailedOlderThanPrevious(issuer, url, NewDownloadAuditor(), time.Now(), time.Now().AddDate(0, 0, -1))
 
 	ent := assertOnlyEntryInList(t, auditor, AuditKindOlderThanLast)
 	assertEntryUrlAndIssuer(t, ent, issuer, url)


### PR DESCRIPTION
 Fixes #113. Most of the "Failed Verify" entries are actually more like
 "Obtained Old CRL", so this special-cases those out into "Older Than Previous"
 and also covers Expiration more clearly, since those were not tracked before.