### PR TITLE
Retry the upload artifact task on transient failure

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,11 @@ setup(
     install_requires=[
         "bsdiff4>=1.1",
         "cryptography>=2.2",
-        "Deprecated >= 1.2",
+        "Deprecated>=1.2",
         "filtercascade>=0.3.1",
         "glog>=0.3",
+        "google-api-core",
+        "google-cloud-core",
         "google-cloud-storage",
         "kinto-http>=9.1",
         "moz_crlite_lib>=0.2",

--- a/workflow/2-upload_artifacts_to_storage
+++ b/workflow/2-upload_artifacts_to_storage
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 from google.cloud import storage
-from google.cloud.retry import Retry
+from google.api_core.retry import Retry
 from pathlib import Path
 from datetime import datetime
 

--- a/workflow/2-upload_artifacts_to_storage
+++ b/workflow/2-upload_artifacts_to_storage
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 from google.cloud import storage
+from google.cloud.retry import Retry
 from pathlib import Path
 from datetime import datetime
 
@@ -27,6 +28,12 @@ parser.add_argument(
 log = logging.getLogger("upload_artifacts_to_storage")
 
 
+@Retry(deadline=60)
+def uploadBlob(bucket, remoteFilePath, localFilePath):
+    blob = bucket.blob(str(remoteFilePath))
+    blob.upload_from_filename(str(localFilePath))
+
+
 def uploadFiles(files, localFolder, remoteFolder, bucket, *, args):
     log.info(f"Uploading {len(files)} files from {localFolder} to {remoteFolder}")
     for item in files:
@@ -44,8 +51,7 @@ def uploadFiles(files, localFolder, remoteFolder, bucket, *, args):
         if args.noop:
             continue
 
-        blob = bucket.blob(str(remoteFilePath))
-        blob.upload_from_filename(str(localFilePath))
+        uploadBlob(bucket, remoteFilePath, localFilePath)
 
 
 def ensureFileOrAbort(runIdPath, path):


### PR DESCRIPTION
Fixes #66, where a transient failure in the uploader caused the whole run to fail. This uses
the Google core Retry mechanism/decorator to retry for 60 seconds on any upload that the
API thinks is transient.