### PR TITLE
Bump moz_crlite_query to permit comments in host files

### DIFF
--- a/containers/crlite-signoff-config.properties.example
+++ b/containers/crlite-signoff-config.properties.example
@@ -17,4 +17,10 @@ KINTO_AUTH_PASSWORD=kinto_signer_example_password
 #
 # Syntax: comma delimited list of accessible urls, containing lines of hosts as
 #         host[:port]
+# and prefixing lines with # or ; to indicate comments. E.g.:
+#
+#   example.com:8443
+#   ; also the following, port 443 assumed
+#   example.net
+#
 crlite_verify_host_file_urls=https://storage.googleapis.com/crlite-verification-domains/mozilla-services-domains.txt, https://storage.googleapis.com/crlite-verification-domains/moz-top500.txt

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         "google-cloud-storage",
         "kinto-http>=9.1",
         "moz_crlite_lib>=0.2",
-        "moz_crlite_query>=0.3.1",
+        "moz_crlite_query>=0.3.2",
         "progressbar2>=3.40",
         "psutil>=5",
         "pyOpenSSL>=17.5",


### PR DESCRIPTION
Version bumps to https://github.com/mozilla/moz_crlite_query/releases/tag/v0.3.2 which supports `#` and `;` as comment identifiers.