### PR TITLE
Add version.json to Docker images.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,16 @@ commands:
         type: string
 
     steps:
+      - run:
+          name: Generate version.json
+          command: |
+            # create a version.json per https://github.com/mozilla-services/Dockerflow/blob/master/docs/version_object.md
+            printf '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n' \
+                "$CIRCLE_SHA1" \
+                "$CIRCLE_TAG" \
+                "$CIRCLE_PROJECT_USERNAME" \
+                "$CIRCLE_PROJECT_REPONAME" \
+                "$CIRCLE_BUILD_URL" > version.json
       - docker/build:
           image: ${DOCKER_IMAGE}
           tag: <<parameters.tag>>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,9 +185,9 @@ workflows:
             - python-build-and-test
             - golang-build-and-test
       - publish-latest-pods:
-          filters:
-            branches:
-              only: main
+          # filters:
+          #   branches:
+          #     only: main
           requires:
             - python-build-and-test
             - golang-build-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,9 +185,9 @@ workflows:
             - python-build-and-test
             - golang-build-and-test
       - publish-latest-pods:
-          # filters:
-          #   branches:
-          #     only: main
+          filters:
+            branches:
+              only: main
           requires:
             - python-build-and-test
             - golang-build-and-test

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -38,7 +38,7 @@ COPY create_filter_cascade /app/create_filter_cascade
 COPY moz_kinto_publisher /app/moz_kinto_publisher
 COPY workflow /app/workflow
 COPY containers/scripts /app/scripts
-COPY setup.py /app/
+COPY setup.py version.json /app/
 RUN pip3 install /app/moz_crlite_lib/ /app/
 
 ENV TINI_VERSION v0.19.0

--- a/version.json
+++ b/version.json
@@ -1,0 +1,6 @@
+{
+    "source" : "https://github.com/mozilla/crlite",
+    "version": "devel",
+    "commit" : "",
+    "build"  : ""
+}


### PR DESCRIPTION
The `version.json` file is [required by the Dockerflow standard](https://github.com/mozilla-services/Dockerflow/blob/master/docs/version_object.md) and used by our automation.

I'll trigger a push of these images by temporarily relaxing the filter, so I can continue testing.