### PR TITLE
Persist CCADB downloads if and only if they load OK

### DIFF
--- a/containers/scripts/crlite-generate.sh
+++ b/containers/scripts/crlite-generate.sh
@@ -16,16 +16,11 @@ if [ ! -d ${ID}/log ] ; then
   mkdir ${ID}/log
 fi
 
-if [ ! -r ${crlite_processing:-/ct}/ccadb-intermediates.csv ] ; then
-  curl https://ccadb-public.secure.force.com/mozilla/MozillaIntermediateCertsCSVReport \
-              --output ${crlite_processing:-/ct}/ccadb-intermediates.csv
-fi
-
 ${crlite_bin:-~/go/bin}/aggregate-crls -crlpath ${crlite_persistent:-/ct}/crls \
               -revokedpath ${ID}/revoked \
               -enrolledpath ${ID}/enrolled.json \
               -auditpath ${ID}/crl-audit.json \
-              -ccadb ${crlite_processing:-/ct}/ccadb-intermediates.csv \
+              -ccadb ${crlite_persistent:-/ct}/ccadb-intermediates.csv \
               -nobars -alsologtostderr -log_dir ${ID}/log
 
 ${crlite_bin:-~/go/bin}/aggregate-known -knownpath ${ID}/known \

--- a/go/cmd/aggregate-crls/aggregate-crls.go
+++ b/go/cmd/aggregate-crls/aggregate-crls.go
@@ -559,11 +559,10 @@ func main() {
 
 	mozIssuers := rootprogram.NewMozillaIssuers()
 	if *inccadb != "<path>" {
-		err = mozIssuers.LoadFromDisk(*inccadb)
-	} else {
-		err = mozIssuers.Load()
+		mozIssuers.DiskPath = *inccadb
 	}
 
+	err = mozIssuers.Load()
 	if err != nil {
 		glog.Fatalf("Unable to load the Mozilla issuers: %s", err)
 	}

--- a/go/cmd/aggregate-crls/aggregate-crls.go
+++ b/go/cmd/aggregate-crls/aggregate-crls.go
@@ -118,6 +118,15 @@ func (ae *AggregateEngine) findCrlWorker(ctx context.Context, wg *sync.WaitGroup
 	resultChan <- issuerCrls
 }
 
+type CrlVerifier struct {
+	expectedIssuerCert *x509.Certificate
+}
+
+func (cv *CrlVerifier) IsValid(path string) error {
+	_, err := loadAndCheckSignatureOfCRL(path, cv.expectedIssuerCert)
+	return err
+}
+
 func (ae *AggregateEngine) crlFetchWorkerProcessOne(ctx context.Context, crlUrl url.URL, issuer storage.Issuer) (string, error) {
 	err := os.MkdirAll(filepath.Join(*crlpath, issuer.ID()), permModeDir)
 	if err != nil {
@@ -126,48 +135,31 @@ func (ae *AggregateEngine) crlFetchWorkerProcessOne(ctx context.Context, crlUrl 
 	}
 
 	filename := makeFilenameFromUrl(crlUrl)
-	tmpPath := filepath.Join(*crlpath, issuer.ID(), filename+".tmp")
 	finalPath := filepath.Join(*crlpath, issuer.ID(), filename)
 
-	dlTracer := downloader.NewDownloadTracer()
-	auditCtx := dlTracer.Configure(ctx)
-
-	err = downloader.DownloadFileSync(auditCtx, ae.display, crlUrl, tmpPath, 3)
+	cert, err := ae.issuers.GetCertificateForIssuer(issuer)
 	if err != nil {
-		glog.Warningf("[%s] Could not download %s to %s: %s", issuer.ID(), crlUrl.String(),
-			tmpPath, err)
-		ae.auditor.FailedDownload(issuer, &crlUrl, dlTracer, err)
-		err = os.Remove(tmpPath)
-		if err != nil {
-			glog.Warningf("[%s] Failed to remove invalid tmp file %s: %s", issuer.ID(), tmpPath, err)
-		}
-	} else {
-		// Validate the file and move it to the finalPath
-		cert, err := ae.issuers.GetCertificateForIssuer(issuer)
-		if err != nil {
-			glog.Fatalf("[%s] Could not find certificate for issuer: %s", issuer.ID(), err)
-		}
+		glog.Fatalf("[%s] Could not find certificate for issuer: %s", issuer.ID(), err)
+	}
 
-		_, err = ae.verifyCRL(issuer, dlTracer, &crlUrl, tmpPath, cert, finalPath)
-		if err != nil {
-			glog.Warningf("[%s] Failed to verify, keeping existing: %s", issuer.ID(), err)
-			// Auditor had its methods called by verifyCRL
-			err = os.Remove(tmpPath)
-			if err != nil {
-				glog.Warningf("[%s] Failed to remove invalid tmp file %s: %s", issuer.ID(), tmpPath, err)
-			}
-		} else {
-			err = os.Rename(tmpPath, finalPath)
-			if err != nil {
-				glog.Errorf("[%s] Couldn't rename %s to %s: %s", issuer.ID(), tmpPath, finalPath, err)
-			}
-		}
+	verifyFunc := &CrlVerifier{
+		expectedIssuerCert: cert,
+	}
+
+	fileOnDiskIsAcceptable, dlErr := downloader.DownloadAndVerifyFileSync(ctx, verifyFunc, ae.auditor, &issuer, ae.display, crlUrl, finalPath, 3)
+	if !fileOnDiskIsAcceptable {
+		glog.Errorf("[%s] Could not download, and no local file, will not be populating the "+
+			"revocations: %s", crlUrl.String(), dlErr)
+		return "", dlErr
+	}
+	if dlErr != nil {
+		glog.Errorf("[%s] Problem downloading: %s", crlUrl.String(), dlErr)
 	}
 
 	// Ensure the final path is acceptable
 	localSize, localDate, err := downloader.GetSizeAndDateOfFile(finalPath)
 	if err != nil {
-		glog.Errorf("[%s] Could not download, and no local file, will not be populating the "+
+		glog.Errorf("[%s] Unexpected error on local file, will not be populating the "+
 			"revocations: %s", crlUrl.String(), err)
 		return "", err
 	}
@@ -175,7 +167,7 @@ func (ae *AggregateEngine) crlFetchWorkerProcessOne(ctx context.Context, crlUrl 
 	age := time.Now().Sub(localDate)
 
 	if age > allowableAgeOfLocalCRL {
-		ae.auditor.Old(issuer, &crlUrl, age)
+		ae.auditor.Old(&issuer, &crlUrl, age)
 		glog.Warningf("[%s] CRL appears very old. Age: %s", crlUrl.String(), age)
 	}
 
@@ -246,26 +238,26 @@ func (ae *AggregateEngine) verifyCRL(aIssuer storage.Issuer, dlTracer *downloade
 
 	crl, err := loadAndCheckSignatureOfCRL(aPath, aIssuerCert)
 	if err != nil {
-		ae.auditor.FailedVerifyUrl(aIssuer, crlUrl, dlTracer, err)
+		ae.auditor.FailedVerifyUrl(&aIssuer, crlUrl, dlTracer, err)
 		return nil, err
 	}
 
 	if _, err = os.Stat(aPreviousPath); err == nil {
 		previousCrl, err := loadAndCheckSignatureOfCRL(aPreviousPath, aIssuerCert)
 		if err != nil {
-			ae.auditor.FailedVerifyPath(aIssuer, aPreviousPath, err)
+			ae.auditor.FailedVerifyPath(&aIssuer, aPreviousPath, err)
 			return nil, err
 		}
 
 		if previousCrl.TBSCertList.ThisUpdate.After(crl.TBSCertList.ThisUpdate) {
-			ae.auditor.FailedOlderThanPrevious(aIssuer, crlUrl, dlTracer, previousCrl.TBSCertList.ThisUpdate, crl.TBSCertList.ThisUpdate)
+			ae.auditor.FailedOlderThanPrevious(&aIssuer, crlUrl, dlTracer, previousCrl.TBSCertList.ThisUpdate, crl.TBSCertList.ThisUpdate)
 			return previousCrl, fmt.Errorf("[%s] CRL is older than the previous CRL (previous=%s, this=%s)",
 				aPath, previousCrl.TBSCertList.ThisUpdate, crl.TBSCertList.ThisUpdate)
 		}
 	}
 
 	if crl.HasExpired(time.Now()) {
-		ae.auditor.Expired(aIssuer, crlUrl, crl.TBSCertList.NextUpdate)
+		ae.auditor.Expired(&aIssuer, crlUrl, crl.TBSCertList.NextUpdate)
 		glog.Warningf("[%s] CRL is expired, but proceeding anyway. (ThisUpdate=%s,"+
 			" NextUpdate=%s)", aPath, crl.TBSCertList.ThisUpdate, crl.TBSCertList.NextUpdate)
 	}
@@ -310,21 +302,21 @@ func (ae *AggregateEngine) aggregateCRLWorker(ctx context.Context, wg *sync.Wait
 			default:
 				crl, err := loadAndCheckSignatureOfCRL(crlPath, cert)
 				if err != nil {
-					ae.auditor.FailedVerifyPath(tuple.Issuer, crlPath, err)
+					ae.auditor.FailedVerifyPath(&tuple.Issuer, crlPath, err)
 					glog.Errorf("[%s] Failed to verify: %s", crlPath, err)
 					continue
 				}
 
 				revokedSerials, err := processCRL(crl)
 				if err != nil {
-					ae.auditor.FailedProcessLocal(tuple.Issuer, crlPath, err)
+					ae.auditor.FailedProcessLocal(&tuple.Issuer, crlPath, err)
 					glog.Errorf("[%s] Failed to process: %s", crlPath, err)
 					continue
 				}
 
 				revokedCount := len(revokedSerials)
 				if revokedCount == 0 {
-					ae.auditor.NoRevocations(tuple.Issuer, crlPath)
+					ae.auditor.NoRevocations(&tuple.Issuer, crlPath)
 					continue
 				}
 

--- a/go/cmd/aggregate-crls/aggregate-crls_test.go
+++ b/go/cmd/aggregate-crls/aggregate-crls_test.go
@@ -362,7 +362,7 @@ func Test_crlFetchWorker(t *testing.T) {
 
 	assertAuditorReportHasEntries(t, auditor, 3)
 	for _, e := range auditor.GetEntries() {
-		assertEntryUrlAndIssuer(t, &e, issuer, unavailableUrl)
+		assertEntryUrlAndIssuer(t, &e, issuer, issuersObj, unavailableUrl)
 	}
 }
 
@@ -430,6 +430,6 @@ func Test_crlFetchWorkerProcessOne(t *testing.T) {
 
 	assertAuditorReportHasEntries(t, auditor, 1)
 	for _, e := range auditor.GetEntries() {
-		assertEntryUrlAndIssuer(t, &e, issuer, unavailableUrl)
+		assertEntryUrlAndIssuer(t, &e, issuer, issuersObj, unavailableUrl)
 	}
 }

--- a/go/cmd/aggregate-crls/aggregate-crls_test.go
+++ b/go/cmd/aggregate-crls/aggregate-crls_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/certificate-transparency-go/x509/pkix"
 	"github.com/jcjones/ct-mapreduce/storage"
 	"github.com/mozilla/crlite/go"
+	"github.com/mozilla/crlite/go/downloader"
 	"github.com/mozilla/crlite/go/rootprogram"
 	"github.com/vbauerster/mpb/v5"
 )
@@ -143,7 +144,7 @@ func Test_loadAndCheckSignatureOfCRL(t *testing.T) {
 
 func Test_verifyCRL(t *testing.T) {
 	issuersObj := rootprogram.NewMozillaIssuers()
-	dlauditor := NewDownloadAuditor()
+	dlTracer := downloader.NewDownloadTracer()
 	auditor := NewCrlAuditor(issuersObj)
 	issuer := issuersObj.NewTestIssuerFromSubjectString("Test Corporation SA")
 	url, _ := url.Parse("http://test/crl")
@@ -196,13 +197,13 @@ func Test_verifyCRL(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = ae.verifyCRL(issuer, dlauditor, url, todayCrlPath.Name(), ca, yesterdayCrlPath.Name())
+	_, err = ae.verifyCRL(issuer, dlTracer, url, todayCrlPath.Name(), ca, yesterdayCrlPath.Name())
 	if !strings.Contains(err.Error(), "CRL is older than the previous CRL") {
 		t.Error(err)
 	}
 
 	// Should work fine this orientation
-	list, err := ae.verifyCRL(issuer, dlauditor, url, yesterdayCrlPath.Name(), ca, todayCrlPath.Name())
+	list, err := ae.verifyCRL(issuer, dlTracer, url, yesterdayCrlPath.Name(), ca, todayCrlPath.Name())
 	if err != nil {
 		t.Error(err)
 	}
@@ -230,7 +231,7 @@ func Test_verifyCRL(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = ae.verifyCRL(issuer, dlauditor, url, todayOtherSignerCrlPath.Name(), ca, yesterdayCrlPath.Name())
+	_, err = ae.verifyCRL(issuer, dlTracer, url, todayOtherSignerCrlPath.Name(), ca, yesterdayCrlPath.Name())
 	if !strings.Contains(err.Error(), "verification failure") {
 		t.Error(err)
 	}

--- a/go/cmd/aggregate-crls/aggregate-crls_test.go
+++ b/go/cmd/aggregate-crls/aggregate-crls_test.go
@@ -397,8 +397,8 @@ func Test_crlFetchWorkerProcessOne(t *testing.T) {
 	unavailableUrl, _ := url.Parse("http://localhost:1/file")
 
 	path, err := ae.crlFetchWorkerProcessOne(context.TODO(), *unavailableUrl, issuer)
-	if err == nil || !strings.Contains(err.Error(), "no such file or directory") {
-		t.Errorf("expected no such file or directory error, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "connect: connection refused") {
+		t.Errorf("expected connect: connection refused error, got %v", err)
 	}
 	if path != "" {
 		t.Errorf("Should not have gotten a path for the unavailable URL: %s", path)

--- a/go/cmd/aggregate-crls/crl-auditor.go
+++ b/go/cmd/aggregate-crls/crl-auditor.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/jcjones/ct-mapreduce/storage"
+	"github.com/mozilla/crlite/go/downloader"
 	"github.com/mozilla/crlite/go/rootprogram"
 )
 
@@ -71,7 +72,7 @@ func (auditor *CrlAuditor) WriteReport(fd io.Writer) error {
 	return enc.Encode(auditor)
 }
 
-func (auditor *CrlAuditor) FailedDownload(issuer storage.Issuer, crlUrl *url.URL, dlAuditor *DownloadAuditor, err error) {
+func (auditor *CrlAuditor) FailedDownload(issuer storage.Issuer, crlUrl *url.URL, dlTracer *downloader.DownloadTracer, err error) {
 	auditor.mutex.Lock()
 	defer auditor.mutex.Unlock()
 
@@ -81,12 +82,12 @@ func (auditor *CrlAuditor) FailedDownload(issuer storage.Issuer, crlUrl *url.URL
 		Url:           crlUrl.String(),
 		Issuer:        issuer,
 		IssuerSubject: auditor.getSubject(issuer),
-		Errors:        append(dlAuditor.Errors(), err.Error()),
-		DNSResults:    dlAuditor.DNSResults(),
+		Errors:        append(dlTracer.Errors(), err.Error()),
+		DNSResults:    dlTracer.DNSResults(),
 	})
 }
 
-func (auditor *CrlAuditor) FailedVerifyUrl(issuer storage.Issuer, crlUrl *url.URL, dlAuditor *DownloadAuditor, err error) {
+func (auditor *CrlAuditor) FailedVerifyUrl(issuer storage.Issuer, crlUrl *url.URL, dlTracer *downloader.DownloadTracer, err error) {
 	auditor.mutex.Lock()
 	defer auditor.mutex.Unlock()
 
@@ -96,12 +97,12 @@ func (auditor *CrlAuditor) FailedVerifyUrl(issuer storage.Issuer, crlUrl *url.UR
 		Url:           crlUrl.String(),
 		Issuer:        issuer,
 		IssuerSubject: auditor.getSubject(issuer),
-		Errors:        append(dlAuditor.Errors(), err.Error()),
-		DNSResults:    dlAuditor.DNSResults(),
+		Errors:        append(dlTracer.Errors(), err.Error()),
+		DNSResults:    dlTracer.DNSResults(),
 	})
 }
 
-func (auditor *CrlAuditor) FailedOlderThanPrevious(issuer storage.Issuer, crlUrl *url.URL, dlAuditor *DownloadAuditor, previous time.Time, this time.Time) {
+func (auditor *CrlAuditor) FailedOlderThanPrevious(issuer storage.Issuer, crlUrl *url.URL, dlTracer *downloader.DownloadTracer, previous time.Time, this time.Time) {
 	auditor.mutex.Lock()
 	defer auditor.mutex.Unlock()
 
@@ -113,8 +114,8 @@ func (auditor *CrlAuditor) FailedOlderThanPrevious(issuer storage.Issuer, crlUrl
 		Url:           crlUrl.String(),
 		Issuer:        issuer,
 		IssuerSubject: auditor.getSubject(issuer),
-		Errors:        append(dlAuditor.Errors(), err),
-		DNSResults:    dlAuditor.DNSResults(),
+		Errors:        append(dlTracer.Errors(), err),
+		DNSResults:    dlTracer.DNSResults(),
 	})
 }
 

--- a/go/cmd/aggregate-crls/crl-auditor_test.go
+++ b/go/cmd/aggregate-crls/crl-auditor_test.go
@@ -149,7 +149,7 @@ func assertAuditorReportHasEntries(t *testing.T, auditor *CrlAuditor, count int)
 	}
 
 	if len(report.Entries) != count {
-		t.Errorf("Expected %d entries but found %d", count, len(report.Entries))
+		t.Errorf("Expected %d audit report entries but found %d", count, len(report.Entries))
 	}
 	for _, e := range report.Entries {
 		e.assertOkay(t)

--- a/go/cmd/aggregate-crls/crl-auditor_test.go
+++ b/go/cmd/aggregate-crls/crl-auditor_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/jcjones/ct-mapreduce/storage"
+	"github.com/mozilla/crlite/go/downloader"
 	"github.com/mozilla/crlite/go/rootprogram"
 )
 
@@ -119,7 +120,7 @@ func Test_FailedDownload(t *testing.T) {
 
 	assertEmptyList(t, auditor)
 
-	auditor.FailedDownload(issuer, url, NewDownloadAuditor(), fmt.Errorf("bad error"))
+	auditor.FailedDownload(issuer, url, downloader.NewDownloadTracer(), fmt.Errorf("bad error"))
 
 	ent := assertOnlyEntryInList(t, auditor, AuditKindFailedDownload)
 	assertEntryUrlAndIssuer(t, ent, issuer, url)
@@ -133,7 +134,7 @@ func Test_FailedVerify(t *testing.T) {
 
 	assertEmptyList(t, auditor)
 
-	auditor.FailedVerifyUrl(issuer, url, NewDownloadAuditor(), fmt.Errorf("bad error"))
+	auditor.FailedVerifyUrl(issuer, url, downloader.NewDownloadTracer(), fmt.Errorf("bad error"))
 
 	ent := assertOnlyEntryInList(t, auditor, AuditKindFailedVerify)
 	assertEntryUrlAndIssuer(t, ent, issuer, url)
@@ -208,7 +209,7 @@ func Test_FailedOlderThanPrevious(t *testing.T) {
 
 	assertEmptyList(t, auditor)
 
-	auditor.FailedOlderThanPrevious(issuer, url, NewDownloadAuditor(), time.Now(), time.Now().AddDate(0, 0, -1))
+	auditor.FailedOlderThanPrevious(issuer, url, downloader.NewDownloadTracer(), time.Now(), time.Now().AddDate(0, 0, -1))
 
 	ent := assertOnlyEntryInList(t, auditor, AuditKindOlderThanLast)
 	assertEntryUrlAndIssuer(t, ent, issuer, url)

--- a/go/downloader/download-auditor.go
+++ b/go/downloader/download-auditor.go
@@ -1,0 +1,13 @@
+package downloader
+
+import (
+	"net/url"
+
+	"github.com/jcjones/ct-mapreduce/storage"
+)
+
+type DownloadAuditor interface {
+	FailedDownload(issuer storage.Issuer, crlUrl *url.URL, dlTracer *DownloadTracer, err error)
+	FailedVerifyUrl(issuer storage.Issuer, crlUrl *url.URL, dlTracer *DownloadTracer, err error)
+	FailedVerifyPath(issuer storage.Issuer, crlPath string, err error)
+}

--- a/go/downloader/download-auditor.go
+++ b/go/downloader/download-auditor.go
@@ -2,12 +2,14 @@ package downloader
 
 import (
 	"net/url"
-
-	"github.com/jcjones/ct-mapreduce/storage"
 )
 
+type DownloadIdentifier interface {
+	ID() string
+}
+
 type DownloadAuditor interface {
-	FailedDownload(issuer storage.Issuer, crlUrl *url.URL, dlTracer *DownloadTracer, err error)
-	FailedVerifyUrl(issuer storage.Issuer, crlUrl *url.URL, dlTracer *DownloadTracer, err error)
-	FailedVerifyPath(issuer storage.Issuer, crlPath string, err error)
+	FailedDownload(identifier DownloadIdentifier, crlUrl *url.URL, dlTracer *DownloadTracer, err error)
+	FailedVerifyUrl(identifier DownloadIdentifier, crlUrl *url.URL, dlTracer *DownloadTracer, err error)
+	FailedVerifyPath(identifier DownloadIdentifier, crlPath string, err error)
 }

--- a/go/downloader/download-tracer.go
+++ b/go/downloader/download-tracer.go
@@ -1,4 +1,4 @@
-package main
+package downloader
 
 import (
 	"context"
@@ -7,22 +7,22 @@ import (
 	"github.com/golang/glog"
 )
 
-type DownloadAuditor struct {
+type DownloadTracer struct {
 	DNSDone []httptrace.DNSDoneInfo
 }
 
-func NewDownloadAuditor() *DownloadAuditor {
-	return &DownloadAuditor{
+func NewDownloadTracer() *DownloadTracer {
+	return &DownloadTracer{
 		DNSDone: []httptrace.DNSDoneInfo{},
 	}
 }
 
-func (da *DownloadAuditor) dnsDone(ddi httptrace.DNSDoneInfo) {
+func (da *DownloadTracer) dnsDone(ddi httptrace.DNSDoneInfo) {
 	glog.V(1).Infof("DNS result: %+v", ddi)
 	da.DNSDone = append(da.DNSDone, ddi)
 }
 
-func (da *DownloadAuditor) Configure(ctx context.Context) context.Context {
+func (da *DownloadTracer) Configure(ctx context.Context) context.Context {
 	traceObj := &httptrace.ClientTrace{
 		DNSDone: da.dnsDone,
 	}
@@ -30,7 +30,7 @@ func (da *DownloadAuditor) Configure(ctx context.Context) context.Context {
 	return httptrace.WithClientTrace(ctx, traceObj)
 }
 
-func (da *DownloadAuditor) DNSResults() []string {
+func (da *DownloadTracer) DNSResults() []string {
 	results := []string{}
 	for _, ddi := range da.DNSDone {
 		for _, addr := range ddi.Addrs {
@@ -40,7 +40,7 @@ func (da *DownloadAuditor) DNSResults() []string {
 	return results
 }
 
-func (da *DownloadAuditor) Errors() []string {
+func (da *DownloadTracer) Errors() []string {
 	results := []string{}
 	for _, ddi := range da.DNSDone {
 		if ddi.Err != nil {

--- a/go/downloader/download-tracer_test.go
+++ b/go/downloader/download-tracer_test.go
@@ -1,4 +1,4 @@
-package main
+package downloader
 
 import (
 	"context"
@@ -6,8 +6,8 @@ import (
 	"testing"
 )
 
-func Test_DlAuditorBlank(t *testing.T) {
-	dla := NewDownloadAuditor()
+func Test_DownloadTracerBlank(t *testing.T) {
+	dla := NewDownloadTracer()
 	if len(dla.DNSResults()) != 0 {
 		t.Error("Should have no DNS results")
 	}
@@ -17,7 +17,7 @@ func Test_DlAuditorBlank(t *testing.T) {
 }
 
 func Test_SingleLookup(t *testing.T) {
-	dla := NewDownloadAuditor()
+	dla := NewDownloadTracer()
 
 	ctx := dla.Configure(context.Background())
 
@@ -41,7 +41,7 @@ func Test_SingleLookup(t *testing.T) {
 }
 
 func Test_SingleLookupError(t *testing.T) {
-	dla := NewDownloadAuditor()
+	dla := NewDownloadTracer()
 
 	ctx := dla.Configure(context.Background())
 

--- a/go/downloader/verifying-downloader.go
+++ b/go/downloader/verifying-downloader.go
@@ -1,0 +1,73 @@
+package downloader
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+
+	"github.com/golang/glog"
+	"github.com/vbauerster/mpb/v5"
+
+	"github.com/jcjones/ct-mapreduce/storage"
+)
+
+type DownloadVerifier interface {
+	IsValid(path string) error
+}
+
+/*
+ * Returns: Boolean of whether the data at finalPath is now valid, and any error. It is possible
+ * that err != nil and yet finalPath is valid, so callers should rely on the boolean and merely
+ * log the error as needed.
+ */
+func DownloadAndVerifyFileSync(ctx context.Context, verifyFunc DownloadVerifier, auditor DownloadAuditor,
+	issuer storage.Issuer, display *mpb.Progress, crlUrl url.URL, finalPath string, maxRetries uint) (bool, error) {
+	dlTracer := NewDownloadTracer()
+	auditCtx := dlTracer.Configure(ctx)
+
+	tmpPath := fmt.Sprintf("%s.tmp", finalPath)
+	defer func() {
+		removeErr := os.Remove(tmpPath)
+		if removeErr != nil && !os.IsNotExist(removeErr) {
+			glog.Warningf("[%s] Failed to remove invalid tmp file %s: %s", issuer.ID(), tmpPath, removeErr)
+		}
+	}()
+
+	dlErr := DownloadFileSync(auditCtx, display, crlUrl, tmpPath, maxRetries)
+	if dlErr != nil {
+		auditor.FailedDownload(issuer, &crlUrl, dlTracer, dlErr)
+		glog.Warningf("[%s] Failed to download from %s to tmp file %s: %s", issuer.ID(), crlUrl.String(), tmpPath, dlErr)
+
+		existingValidErr := verifyFunc.IsValid(finalPath)
+		if existingValidErr == nil {
+			// The existing file at finalPath is OK.
+			return true, dlErr
+		}
+		return false, dlErr
+	}
+
+	dlValidErr := verifyFunc.IsValid(tmpPath)
+	if dlValidErr != nil {
+		auditor.FailedVerifyUrl(issuer, &crlUrl, dlTracer, dlValidErr)
+
+		existingValidErr := verifyFunc.IsValid(finalPath)
+		if existingValidErr == nil {
+			// The existing file at finalPath is OK.
+			return true, dlValidErr
+		}
+
+		auditor.FailedVerifyPath(issuer, finalPath, existingValidErr)
+		glog.Errorf("[%s] Couldn't verify already-on-disk path %s: %s", issuer.ID(), finalPath, existingValidErr)
+		return false, existingValidErr
+	}
+
+	renameErr := os.Rename(tmpPath, finalPath)
+	if renameErr != nil {
+		glog.Errorf("[%s] Couldn't rename %s to %s: %s", issuer.ID(), tmpPath, finalPath, renameErr)
+		return false, renameErr
+	}
+
+	return true, nil
+
+}

--- a/go/downloader/verifying-downloader_test.go
+++ b/go/downloader/verifying-downloader_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/vbauerster/mpb/v5"
@@ -68,7 +69,7 @@ func Test_NotFoundNotLocal(t *testing.T) {
 	if dataAtPathIsValid {
 		t.Error("Expected not dataAtPathIsValid")
 	}
-	if err.Error() != "Non-OK status: 404 Not Found" {
+	if !strings.Contains(err.Error(), "Local error=Empty file, Caused by=Non-OK status: 404 Not Found") {
 		t.Error(err)
 	}
 

--- a/go/downloader/verifying-downloader_test.go
+++ b/go/downloader/verifying-downloader_test.go
@@ -1,0 +1,186 @@
+package downloader
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/jcjones/ct-mapreduce/storage"
+	"github.com/vbauerster/mpb/v5"
+)
+
+type testVerifier struct{}
+
+func (tv *testVerifier) IsValid(path string) error {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	if len(data) == 0 {
+		return fmt.Errorf("Empty file")
+	}
+	return nil
+}
+
+type testAuditor struct{}
+
+func (ta *testAuditor) FailedDownload(issuer storage.Issuer, crlUrl *url.URL, dlTracer *DownloadTracer, err error) {
+}
+func (ta *testAuditor) FailedVerifyUrl(issuer storage.Issuer, crlUrl *url.URL, dlTracer *DownloadTracer, err error) {
+}
+func (ta *testAuditor) FailedVerifyPath(issuer storage.Issuer, crlPath string, err error) {}
+
+func Test_NotFoundNotLocal(t *testing.T) {
+	ts := httptest.NewServer(http.NotFoundHandler())
+	defer ts.Close()
+
+	display := mpb.New(
+		mpb.WithOutput(ioutil.Discard),
+	)
+
+	tmpfile, err := ioutil.TempFile("", "Test_NotFoundNotLocal")
+	if err != nil {
+		t.Error(err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	testUrl, _ := url.Parse(ts.URL)
+
+	ctx := context.TODO()
+
+	dataAtPathIsValid, err := DownloadAndVerifyFileSync(ctx, &testVerifier{}, &testAuditor{},
+		storage.NewIssuerFromString("this issuer"), display, *testUrl,
+		tmpfile.Name(), 1)
+
+	if err == nil {
+		t.Error("Expected error")
+	}
+	if dataAtPathIsValid {
+		t.Error("Expected not dataAtPathIsValid")
+	}
+	if err.Error() != "Non-OK status: 404 Not Found" {
+		t.Error(err)
+	}
+
+	_, statErr := os.Stat(fmt.Sprintf("%s.tmp", tmpfile.Name()))
+	if statErr == nil {
+		t.Error("tmpfile not cleaned up")
+	}
+}
+
+func Test_NotFoundButIsLocal(t *testing.T) {
+	ts := httptest.NewServer(http.NotFoundHandler())
+	defer ts.Close()
+
+	display := mpb.New(
+		mpb.WithOutput(ioutil.Discard),
+	)
+
+	tmpfile, err := ioutil.TempFile("", "Test_NotFoundButIsLocal")
+	if err != nil {
+		t.Error(err)
+	}
+	defer os.Remove(tmpfile.Name())
+	ioutil.WriteFile(tmpfile.Name(), []byte("Local File"), 0644)
+
+	testUrl, _ := url.Parse(ts.URL)
+
+	ctx := context.TODO()
+
+	dataAtPathIsValid, err := DownloadAndVerifyFileSync(ctx, &testVerifier{}, &testAuditor{},
+		storage.NewIssuerFromString("this issuer"), display, *testUrl,
+		tmpfile.Name(), 1)
+
+	if err == nil {
+		t.Error("Expected error")
+	}
+	if !dataAtPathIsValid {
+		t.Error("Expected dataAtPathIsValid!")
+	}
+	if err.Error() != "Non-OK status: 404 Not Found" {
+		t.Error(err)
+	}
+
+	_, statErr := os.Stat(fmt.Sprintf("%s.tmp", tmpfile.Name()))
+	if statErr == nil {
+		t.Error("tmpfile not cleaned up")
+	}
+}
+
+func Test_FoundRemoteButNotLocal(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "Hello, client")
+	}))
+	defer ts.Close()
+
+	display := mpb.New(
+		mpb.WithOutput(ioutil.Discard),
+	)
+
+	tmpfile, err := ioutil.TempFile("", "Test_FoundRemoteButNotLocal")
+	if err != nil {
+		t.Error(err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	testUrl, _ := url.Parse(ts.URL)
+
+	ctx := context.TODO()
+
+	dataAtPathIsValid, err := DownloadAndVerifyFileSync(ctx, &testVerifier{}, &testAuditor{},
+		storage.NewIssuerFromString("this issuer"), display, *testUrl,
+		tmpfile.Name(), 1)
+
+	if err != nil {
+		t.Errorf("Expected no error but got %s", err)
+	}
+	if !dataAtPathIsValid {
+		t.Error("Expected dataAtPathIsValid")
+	}
+	_, statErr := os.Stat(fmt.Sprintf("%s.tmp", tmpfile.Name()))
+	if statErr == nil {
+		t.Error("tmpfile not cleaned up")
+	}
+}
+
+func Test_FoundRemoteAndAlsoLocal(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "Hello, client")
+	}))
+	defer ts.Close()
+
+	display := mpb.New(
+		mpb.WithOutput(ioutil.Discard),
+	)
+
+	tmpfile, err := ioutil.TempFile("", "Test_FoundRemoteAndAlsoLocal")
+	if err != nil {
+		t.Error(err)
+	}
+	defer os.Remove(tmpfile.Name())
+	ioutil.WriteFile(tmpfile.Name(), []byte("Local File"), 0644)
+
+	testUrl, _ := url.Parse(ts.URL)
+
+	ctx := context.TODO()
+
+	dataAtPathIsValid, err := DownloadAndVerifyFileSync(ctx, &testVerifier{}, &testAuditor{},
+		storage.NewIssuerFromString("this issuer"), display, *testUrl,
+		tmpfile.Name(), 1)
+
+	if err != nil {
+		t.Errorf("Expected no error but got %s", err)
+	}
+	if !dataAtPathIsValid {
+		t.Error("Expected dataAtPathIsValid")
+	}
+	_, statErr := os.Stat(fmt.Sprintf("%s.tmp", tmpfile.Name()))
+	if statErr == nil {
+		t.Error("tmpfile not cleaned up")
+	}
+}

--- a/go/downloader/verifying-downloader_test.go
+++ b/go/downloader/verifying-downloader_test.go
@@ -10,9 +10,14 @@ import (
 	"os"
 	"testing"
 
-	"github.com/jcjones/ct-mapreduce/storage"
 	"github.com/vbauerster/mpb/v5"
 )
+
+type testIdentifier struct{}
+
+func (ti testIdentifier) ID() string {
+	return "test identifier"
+}
 
 type testVerifier struct{}
 
@@ -29,11 +34,11 @@ func (tv *testVerifier) IsValid(path string) error {
 
 type testAuditor struct{}
 
-func (ta *testAuditor) FailedDownload(issuer storage.Issuer, crlUrl *url.URL, dlTracer *DownloadTracer, err error) {
+func (ta *testAuditor) FailedDownload(issuer DownloadIdentifier, crlUrl *url.URL, dlTracer *DownloadTracer, err error) {
 }
-func (ta *testAuditor) FailedVerifyUrl(issuer storage.Issuer, crlUrl *url.URL, dlTracer *DownloadTracer, err error) {
+func (ta *testAuditor) FailedVerifyUrl(issuer DownloadIdentifier, crlUrl *url.URL, dlTracer *DownloadTracer, err error) {
 }
-func (ta *testAuditor) FailedVerifyPath(issuer storage.Issuer, crlPath string, err error) {}
+func (ta *testAuditor) FailedVerifyPath(issuer DownloadIdentifier, crlPath string, err error) {}
 
 func Test_NotFoundNotLocal(t *testing.T) {
 	ts := httptest.NewServer(http.NotFoundHandler())
@@ -54,7 +59,7 @@ func Test_NotFoundNotLocal(t *testing.T) {
 	ctx := context.TODO()
 
 	dataAtPathIsValid, err := DownloadAndVerifyFileSync(ctx, &testVerifier{}, &testAuditor{},
-		storage.NewIssuerFromString("this issuer"), display, *testUrl,
+		&testIdentifier{}, display, *testUrl,
 		tmpfile.Name(), 1)
 
 	if err == nil {
@@ -93,7 +98,7 @@ func Test_NotFoundButIsLocal(t *testing.T) {
 	ctx := context.TODO()
 
 	dataAtPathIsValid, err := DownloadAndVerifyFileSync(ctx, &testVerifier{}, &testAuditor{},
-		storage.NewIssuerFromString("this issuer"), display, *testUrl,
+		&testIdentifier{}, display, *testUrl,
 		tmpfile.Name(), 1)
 
 	if err == nil {
@@ -133,7 +138,7 @@ func Test_FoundRemoteButNotLocal(t *testing.T) {
 	ctx := context.TODO()
 
 	dataAtPathIsValid, err := DownloadAndVerifyFileSync(ctx, &testVerifier{}, &testAuditor{},
-		storage.NewIssuerFromString("this issuer"), display, *testUrl,
+		&testIdentifier{}, display, *testUrl,
 		tmpfile.Name(), 1)
 
 	if err != nil {
@@ -170,7 +175,7 @@ func Test_FoundRemoteAndAlsoLocal(t *testing.T) {
 	ctx := context.TODO()
 
 	dataAtPathIsValid, err := DownloadAndVerifyFileSync(ctx, &testVerifier{}, &testAuditor{},
-		storage.NewIssuerFromString("this issuer"), display, *testUrl,
+		&testIdentifier{}, display, *testUrl,
 		tmpfile.Name(), 1)
 
 	if err != nil {

--- a/go/rootprogram/issuers.go
+++ b/go/rootprogram/issuers.go
@@ -49,16 +49,16 @@ type EnrolledIssuer struct {
 type MozIssuers struct {
 	issuerMap map[string]IssuerData
 	mutex     *sync.Mutex
-	diskPath  string
-	reportUrl string
+	DiskPath  string
+	ReportUrl string
 }
 
 func NewMozillaIssuers() *MozIssuers {
 	return &MozIssuers{
 		issuerMap: make(map[string]IssuerData, 0),
 		mutex:     &sync.Mutex{},
-		diskPath:  fmt.Sprintf("%s/mozilla_issuers.csv", os.TempDir()),
-		reportUrl: kMozCCADBReport,
+		DiskPath:  fmt.Sprintf("%s/mozilla_issuers.csv", os.TempDir()),
+		ReportUrl: kMozCCADBReport,
 	}
 }
 
@@ -95,13 +95,13 @@ func (mi *MozIssuers) Load() error {
 		mpb.WithOutput(ioutil.Discard),
 	)
 
-	dataUrl, err := url.Parse(mi.reportUrl)
+	dataUrl, err := url.Parse(mi.ReportUrl)
 	if err != nil {
-		glog.Fatalf("Couldn't parse CCADB URL of %s: %s", mi.reportUrl, err)
+		glog.Fatalf("Couldn't parse CCADB URL of %s: %s", mi.ReportUrl, err)
 	}
 
 	isAcceptable, err := downloader.DownloadAndVerifyFileSync(ctx, &verifier{}, &loggingAuditor{}, &identifier{},
-		display, *dataUrl, mi.diskPath, 3)
+		display, *dataUrl, mi.DiskPath, 3)
 
 	if !isAcceptable {
 		return err
@@ -111,7 +111,7 @@ func (mi *MozIssuers) Load() error {
 		glog.Warningf("Error encountered loading CCADB data, but able to proceed with previous data. Error: %s", err)
 	}
 
-	return mi.LoadFromDisk(mi.diskPath)
+	return mi.LoadFromDisk(mi.DiskPath)
 }
 
 func (mi *MozIssuers) LoadFromDisk(aPath string) error {

--- a/go/rootprogram/issuers.go
+++ b/go/rootprogram/issuers.go
@@ -101,6 +101,7 @@ func (mi *MozIssuers) Load() error {
 	dataUrl, err := url.Parse(mi.ReportUrl)
 	if err != nil {
 		glog.Fatalf("Couldn't parse CCADB URL of %s: %s", mi.ReportUrl, err)
+		return err
 	}
 
 	isAcceptable, err := downloader.DownloadAndVerifyFileSync(ctx, &verifier{}, &loggingAuditor{}, &identifier{},

--- a/go/rootprogram/issuers.go
+++ b/go/rootprogram/issuers.go
@@ -57,7 +57,7 @@ func NewMozillaIssuers() *MozIssuers {
 	return &MozIssuers{
 		issuerMap: make(map[string]IssuerData, 0),
 		mutex:     &sync.Mutex{},
-		diskPath:  "/tmp/mozissuers",
+		diskPath:  fmt.Sprintf("%s/mozilla_issuers.csv", os.TempDir()),
 		reportUrl: kMozCCADBReport,
 	}
 }

--- a/go/rootprogram/issuers.go
+++ b/go/rootprogram/issuers.go
@@ -72,13 +72,16 @@ func (v *verifier) IsValid(path string) error {
 
 type loggingAuditor struct{}
 
-func (ta *loggingAuditor) FailedDownload(issuer downloader.DownloadIdentifier, crlUrl *url.URL, dlTracer *downloader.DownloadTracer, err error) {
+func (ta *loggingAuditor) FailedDownload(issuer downloader.DownloadIdentifier, crlUrl *url.URL,
+	dlTracer *downloader.DownloadTracer, err error) {
 	glog.Warningf("Failed download of %s: %s", crlUrl.String(), err)
 }
-func (ta *loggingAuditor) FailedVerifyUrl(issuer downloader.DownloadIdentifier, crlUrl *url.URL, dlTracer *downloader.DownloadTracer, err error) {
+func (ta *loggingAuditor) FailedVerifyUrl(issuer downloader.DownloadIdentifier, crlUrl *url.URL,
+	dlTracer *downloader.DownloadTracer, err error) {
 	glog.Warningf("Failed verify of %s: %s", crlUrl.String(), err)
 }
-func (ta *loggingAuditor) FailedVerifyPath(issuer downloader.DownloadIdentifier, crlPath string, err error) {
+func (ta *loggingAuditor) FailedVerifyPath(issuer downloader.DownloadIdentifier, crlPath string,
+	err error) {
 	glog.Warningf("Failed verify of %s: %s", crlPath, err)
 }
 

--- a/go/rootprogram/issuers_test.go
+++ b/go/rootprogram/issuers_test.go
@@ -408,8 +408,8 @@ func Test_LoadFromURL(t *testing.T) {
 	defer os.Remove(tmpfile.Name())
 
 	mi := NewMozillaIssuers()
-	mi.reportUrl = ts.URL
-	mi.diskPath = tmpfile.Name()
+	mi.ReportUrl = ts.URL
+	mi.DiskPath = tmpfile.Name()
 
 	err = mi.Load()
 	if err != nil {
@@ -424,7 +424,7 @@ func Test_LoadFromURL(t *testing.T) {
 		t.Errorf("Unexpected certificate subject: %s", subject)
 	}
 
-	_, err = os.Stat(mi.diskPath)
+	_, err = os.Stat(mi.DiskPath)
 	if err != nil {
 		t.Error(err)
 	}
@@ -437,8 +437,8 @@ func Test_LoadFromURLToDefaultLocation(t *testing.T) {
 	defer ts.Close()
 
 	mi := NewMozillaIssuers()
-	mi.reportUrl = ts.URL
-	defer os.Remove(mi.diskPath)
+	mi.ReportUrl = ts.URL
+	defer os.Remove(mi.DiskPath)
 
 	err := mi.Load()
 	if err != nil {
@@ -453,7 +453,7 @@ func Test_LoadFromURLToDefaultLocation(t *testing.T) {
 		t.Errorf("Unexpected certificate subject: %s", subject)
 	}
 
-	_, err = os.Stat(mi.diskPath)
+	_, err = os.Stat(mi.DiskPath)
 	if err != nil {
 		t.Error(err)
 	}
@@ -470,8 +470,8 @@ func Test_LoadFrom404URLNoLocal(t *testing.T) {
 	defer os.Remove(tmpfile.Name())
 
 	mi := NewMozillaIssuers()
-	mi.reportUrl = ts.URL
-	mi.diskPath = tmpfile.Name()
+	mi.ReportUrl = ts.URL
+	mi.DiskPath = tmpfile.Name()
 
 	err = mi.Load()
 	if err == nil {
@@ -486,7 +486,7 @@ func Test_LoadFrom404URLNoLocal(t *testing.T) {
 		t.Errorf("Unexpected certificate subject: %s", subject)
 	}
 
-	_, err = os.Stat(mi.diskPath)
+	_, err = os.Stat(mi.DiskPath)
 	if err != nil {
 		t.Error(err)
 	}
@@ -508,8 +508,8 @@ func Test_LoadFrom404URLWithLocal(t *testing.T) {
 	}
 
 	mi := NewMozillaIssuers()
-	mi.reportUrl = ts.URL
-	mi.diskPath = tmpfile.Name()
+	mi.ReportUrl = ts.URL
+	mi.DiskPath = tmpfile.Name()
 
 	err = mi.Load()
 	if err != nil {
@@ -524,7 +524,7 @@ func Test_LoadFrom404URLWithLocal(t *testing.T) {
 		t.Errorf("Unexpected certificate subject: %s", subject)
 	}
 
-	_, err = os.Stat(mi.diskPath)
+	_, err = os.Stat(mi.DiskPath)
 	if err != nil {
 		t.Error(err)
 	}
@@ -548,8 +548,8 @@ func Test_LoadInvalidWithLocal(t *testing.T) {
 	}
 
 	mi := NewMozillaIssuers()
-	mi.reportUrl = ts.URL
-	mi.diskPath = tmpfile.Name()
+	mi.ReportUrl = ts.URL
+	mi.DiskPath = tmpfile.Name()
 
 	err = mi.Load()
 	if err != nil {
@@ -564,7 +564,7 @@ func Test_LoadInvalidWithLocal(t *testing.T) {
 		t.Errorf("Unexpected certificate subject: %s", subject)
 	}
 
-	_, err = os.Stat(mi.diskPath)
+	_, err = os.Stat(mi.DiskPath)
 	if err != nil {
 		t.Error(err)
 	}
@@ -583,8 +583,8 @@ func Test_LoadInvalidWithNoLocal(t *testing.T) {
 	defer os.Remove(tmpfile.Name())
 
 	mi := NewMozillaIssuers()
-	mi.reportUrl = ts.URL
-	mi.diskPath = tmpfile.Name()
+	mi.ReportUrl = ts.URL
+	mi.DiskPath = tmpfile.Name()
 
 	err = mi.Load()
 	if err == nil {

--- a/go/rootprogram/issuers_test.go
+++ b/go/rootprogram/issuers_test.go
@@ -8,8 +8,12 @@ import (
 	"crypto/x509/pkix"
 	"encoding/json"
 	"encoding/pem"
+	"fmt"
 	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -58,6 +62,9 @@ cxhzf8XjZXECKL54a/4o9ISBcA==
 `
 	kFirstTwoLinesIssuerID = "6z9CPfvSI57njPXWYOU61nQPaO9b2blTtyMZoCaRT4g="
 	kFirstTwoLinesSubject  = "SERIALNUMBER=A82743287,CN=RACER,O=AC Camerfirma SA,L=Madrid (see current address at www.camerfirma.com/address),C=ES"
+
+	kFirstTwoLinesNoPem = `"CA Owner","Parent Name","Certificate Name","Certificate Issuer Common Name","Certificate Issuer Organization","Certificate Issuer Organizational Unit","Certificate Subject Common Name","Certificate Subject Organization","Certificate Serial Number","SHA-1 Fingerprint","SHA-256 Fingerprint","Subject + SPKI SHA256","Technically Constrained","Valid From [GMT]","Valid To [GMT]","CRL URL(s)","Public Key Algorithm","Signature Hash Algorithm","Key Usage","Extended Key Usage","CP/CPS Same As Parent","Certificate Policy (CP)","Certification Practice Statement (CPS)","Audits Same As Parent","Standard Audit","BR Audit","Auditor","Standard Audit Statement Dt","Management Assertions By","Comments","PEM"
+"AC Camerfirma, S.A.","AC Camerfirma","RACER","AC Camerfirma","AC Camerfirma SA","","RACER","AC Camerfirma SA","01","F82701F8E04770F3448C19070F9B2158B16621A0","F1712177935DBA40BDBD99C5F753319CF6293549B7284741E43916AD3BFBDD75","80C14510C26519770718D4086A713C32DBC2209FF30B2AAA36523CC310424096","false","2003 Dec 04","2023 Dec 04","http://crl.camerfirma.com/racer.crl","RSA 2047 bits","SHA1WithRSA","Digital Signature, Certificate Sign, CRL Sign","(not present)","TRUE","","","TRUE","","","","","","",""`
 
 	kEmptyAKI = `"CA Owner","Parent Name","Certificate Name","Certificate Issuer Common Name","Certificate Issuer Organization","Certificate Issuer Organizational Unit","Certificate Subject Common Name","Certificate Subject Organization","Certificate Serial Number","SHA-1 Fingerprint","SHA-256 Fingerprint","Subject + SPKI SHA256","Technically Constrained","Valid From [GMT]","Valid To [GMT]","CRL URL(s)","Public Key Algorithm","Signature Hash Algorithm","Key Usage","Extended Key Usage","CP/CPS Same As Parent","Certificate Policy (CP)","Certification Practice Statement (CPS)","Audits Same As Parent","Standard Audit","BR Audit","Auditor","Standard Audit Statement Dt","Management Assertions By","Comments","PEM"
 "Test Corporation","Test Corporation","test","Test Corporation","Test Corporation CA","","test","Test Corporation CA","71:8a:bd:2f:20:13:18:ea:a2:73:67:b0:3d:b5:3f:6b:24:3c:f6:f5","F82701F8E04770F3448C19070F9B2158B16621A0","F1712177935DBA40BDBD99C5F753319CF6293549B7284741E43916AD3BFBDD75","80C14510C26519770718D4086A713C32DBC2209FF30B2AAA36523CC310424096","false","2016 Nov 27","2019 Feb 05","http://crl.example.com/test.crl","RSA 2048 bits","SHA1WithRSA","Digital Signature, Certificate Sign, CRL Sign","(not present)","TRUE","","","TRUE","","","","","","","'-----BEGIN CERTIFICATE-----
@@ -385,5 +392,173 @@ func Test_NewTestIssuerFromSubjectString(t *testing.T) {
 	}
 	if subject != "a subject" {
 		t.Errorf("Unexpected subject: %v", subject)
+	}
+}
+
+func Test_LoadFromURL(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, kFirstTwoLines)
+	}))
+	defer ts.Close()
+
+	tmpfile, err := ioutil.TempFile("", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	mi := NewMozillaIssuers()
+	mi.reportUrl = ts.URL
+	mi.diskPath = tmpfile.Name()
+
+	err = mi.Load()
+	if err != nil {
+		t.Error(err)
+	}
+
+	subject, err := mi.GetSubjectForIssuer(storage.NewIssuerFromString(kFirstTwoLinesIssuerID))
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	if subject != kFirstTwoLinesSubject {
+		t.Errorf("Unexpected certificate subject: %s", subject)
+	}
+
+	_, err = os.Stat(mi.diskPath)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func Test_LoadFrom404URLNoLocal(t *testing.T) {
+	ts := httptest.NewServer(http.NotFoundHandler())
+	defer ts.Close()
+
+	tmpfile, err := ioutil.TempFile("", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	mi := NewMozillaIssuers()
+	mi.reportUrl = ts.URL
+	mi.diskPath = tmpfile.Name()
+
+	err = mi.Load()
+	if err == nil {
+		t.Error("Expected failure")
+	}
+
+	subject, err := mi.GetSubjectForIssuer(storage.NewIssuerFromString(kFirstTwoLinesIssuerID))
+	if err == nil || !strings.Contains(err.Error(), "Unknown issuer") {
+		t.Errorf("Expected error, got: %s", err)
+	}
+	if len(subject) != 0 {
+		t.Errorf("Unexpected certificate subject: %s", subject)
+	}
+
+	_, err = os.Stat(mi.diskPath)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func Test_LoadFrom404URLWithLocal(t *testing.T) {
+	ts := httptest.NewServer(http.NotFoundHandler())
+	defer ts.Close()
+
+	tmpfile, err := ioutil.TempFile("", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	err = ioutil.WriteFile(tmpfile.Name(), []byte(kFirstTwoLines), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mi := NewMozillaIssuers()
+	mi.reportUrl = ts.URL
+	mi.diskPath = tmpfile.Name()
+
+	err = mi.Load()
+	if err != nil {
+		t.Errorf("Expected success with local file, got %s", err)
+	}
+
+	subject, err := mi.GetSubjectForIssuer(storage.NewIssuerFromString(kFirstTwoLinesIssuerID))
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	if subject != kFirstTwoLinesSubject {
+		t.Errorf("Unexpected certificate subject: %s", subject)
+	}
+
+	_, err = os.Stat(mi.diskPath)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func Test_LoadInvalidWithLocal(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, kFirstTwoLinesNoPem)
+	}))
+	defer ts.Close()
+
+	tmpfile, err := ioutil.TempFile("", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	err = ioutil.WriteFile(tmpfile.Name(), []byte(kFirstTwoLines), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mi := NewMozillaIssuers()
+	mi.reportUrl = ts.URL
+	mi.diskPath = tmpfile.Name()
+
+	err = mi.Load()
+	if err != nil {
+		t.Errorf("Expected success with local file, got %s", err)
+	}
+
+	subject, err := mi.GetSubjectForIssuer(storage.NewIssuerFromString(kFirstTwoLinesIssuerID))
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	if subject != kFirstTwoLinesSubject {
+		t.Errorf("Unexpected certificate subject: %s", subject)
+	}
+
+	_, err = os.Stat(mi.diskPath)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func Test_LoadInvalidWithNoLocal(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, kFirstTwoLinesNoPem)
+	}))
+	defer ts.Close()
+
+	tmpfile, err := ioutil.TempFile("", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	mi := NewMozillaIssuers()
+	mi.reportUrl = ts.URL
+	mi.diskPath = tmpfile.Name()
+
+	err = mi.Load()
+	if err == nil {
+		t.Error("Expected failure")
 	}
 }


### PR DESCRIPTION
This is a fairly large patch, but broken into logical commits. It:
* Refactors the CRL Audit tools into the `downloader` class
* Constructs a "Verifying Downloader" based on the `aggregate-crls` approach of download-and-verify-and-rename used for CRLs
* Uses the new verifying downloader for CRLs and adapts tests
* Uses the new verifying downloader for the Mozilla Issuers data from the CCADB
* Adapts the `aggregate-crls` tool and its script to store the CCADB into the persistent folder

Local log with a valid file on-disk and the currently-problematic one from #123 served by the CCADB:

```
I0720 23:31:50.984102   64274 config.go:176] Loaded config file from /Users/jcjones/.ct-fetch.ini
I0720 23:31:50.996565   64274 aggregate-crls.go:554] Progress bar refresh rate is every 125ms.
I0720 23:31:50.996601   64274 engine.go:76] aggregate-crls is starting. Local statistics will emit every: 1m0s
W0720 23:31:54.285309   64274 issuers.go:79] Failed verify of https://ccadb-public.secure.force.com/mozilla/MozillaIntermediateCertsCSVReport: Not a valid PEM at line 29950
W0720 23:31:54.387808   64274 issuers.go:111] Error encountered loading CCADB data, but able to proceed with previous data. Error: Not a valid PEM at line 29950
```
