### PR TITLE
Handle empty storage bucket

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         "google-cloud-storage",
         "kinto-http>=9.1",
         "moz_crlite_lib>=0.2",
-        "moz_crlite_query>=0.3.2",
+        "moz_crlite_query>=0.3.3",
         "progressbar2>=3.40",
         "psutil>=5",
         "pyOpenSSL>=17.5",

--- a/workflow/1-generate_mlbf
+++ b/workflow/1-generate_mlbf
@@ -40,10 +40,10 @@ def main():
 
     cmdline = cmdline + args.identifier
 
-    if not args.nodiff and "GOOGLE_APPLICATION_CREDENTIALS" in os.environ:
+    all_runs = workflow.get_run_identifiers(args.filter_bucket)
+    if all_runs and not args.nodiff and "GOOGLE_APPLICATION_CREDENTIALS" in os.environ:
         try:
-            latest = workflow.get_run_identifiers(args.filter_bucket).pop()
-
+            latest = all_runs.pop()
             dest = Path(tempfile.mkdtemp()) / Path(latest)
             dest.mkdir()
 
@@ -61,6 +61,8 @@ def main():
             cmdline = cmdline + ["-previd", dest]
         except exceptions.NotFound as e:
             log.error(f"Could not download existing filter: {e}")
+        except Exception as e:
+            log.error(f"Could not get any existing filter: {e}")
 
     log.info(f"Running {cmdline}")
     subprocess.run(cmdline, check=True)

--- a/workflow/1-generate_mlbf
+++ b/workflow/1-generate_mlbf
@@ -40,25 +40,26 @@ def main():
 
     cmdline = cmdline + args.identifier
 
-    all_runs = workflow.get_run_identifiers(args.filter_bucket)
-    if all_runs and not args.nodiff and "GOOGLE_APPLICATION_CREDENTIALS" in os.environ:
+    if not args.nodiff and "GOOGLE_APPLICATION_CREDENTIALS" in os.environ:
         try:
-            latest = all_runs.pop()
-            dest = Path(tempfile.mkdtemp()) / Path(latest)
-            dest.mkdir()
+            all_runs = workflow.get_run_identifiers(args.filter_bucket)
+            if all_runs:
+                latest = all_runs.pop()
+                dest = Path(tempfile.mkdtemp()) / Path(latest)
+                dest.mkdir()
 
-            workflow.download_from_google_cloud(
-                args.filter_bucket,
-                f"{latest}/mlbf/list-revoked.keys",
-                dest / Path("list-revoked.keys"),
-            )
-            workflow.download_from_google_cloud(
-                args.filter_bucket,
-                f"{latest}/mlbf/list-valid.keys",
-                dest / Path("list-valid.keys"),
-            )
+                workflow.download_from_google_cloud(
+                    args.filter_bucket,
+                    f"{latest}/mlbf/list-revoked.keys",
+                    dest / Path("list-revoked.keys"),
+                )
+                workflow.download_from_google_cloud(
+                    args.filter_bucket,
+                    f"{latest}/mlbf/list-valid.keys",
+                    dest / Path("list-valid.keys"),
+                )
 
-            cmdline = cmdline + ["-previd", dest]
+                cmdline = cmdline + ["-previd", dest]
         except exceptions.NotFound as e:
             log.error(f"Could not download existing filter: {e}")
         except Exception as e:


### PR DESCRIPTION
Fixes the following two issues which happen on an empty bucket:

```
Traceback (most recent call last):
  File "/app/workflow/1-generate_mlbf", line 71, in <module>
    main()
  File "/app/workflow/1-generate_mlbf", line 45, in main
    latest = workflow.get_run_identifiers(args.filter_bucket).pop()
IndexError: pop from empty list
```
and
```
Traceback (most recent call last):
  File "/usr/local/bin/moz_crlite_query", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.8/site-packages/crlite_query/query_cli.py", line 215, in main
    for result in query.query(name=name, generator=generator):
  File "/usr/local/lib/python3.8/site-packages/crlite_query/__init__.py", line 517, in query
    cert_id = CertId(issuer["issuerId"], serial_bytes)
TypeError: 'NoneType' object is not subscriptable
CRITICAL:signoff-tool:Error in moz_crlite_query: Command '['/usr/local/bin/python3', '/usr/local/bin/moz_crlite_query', '--use-filter', PosixPath('/tmp/tmpfeigahnw/2020-07-30T18:00:15Z-full'), '--check-not-revoked', '--hosts-file', '/tmp/tmpfeigahnw/b03056cf3f3486d1f940ee6759f63e1661a6a708c4615a08841b17f69b9cf2ae', '--hosts-file', '/tmp/tmpfeigahnw/b496cd1bb056bdf5e436151f27d3884cf667de536b63de808bed518805eae951']' returned non-zero exit status 1.
```