### PR TITLE
Rename Docker user to "app" and change UID.

### DIFF
--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -19,7 +19,7 @@ RUN apt update && apt install -y ca-certificates && \
     apt-get -y clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN adduser --system --home /app appuser
+RUN adduser --system --uid 10001 --group --home /app app
 
 ENV crlite_log /var/log
 ENV crlite_processing /processing
@@ -27,7 +27,7 @@ ENV crlite_persistent /persistent
 ENV crlite_workflow /app/workflow
 ENV crlite_bin /app
 
-RUN mkdir /processing && chown appuser /processing && chmod 777 /processing
+RUN mkdir /processing && chown app /processing && chmod 777 /processing
 VOLUME /var/log /processing /persistent
 
 COPY --from=builder /build/bin /app/
@@ -46,7 +46,7 @@ ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 ENTRYPOINT ["/tini", "-g", "--"]
 
-USER appuser
+USER app
 WORKDIR /app
 
 ENV outputRefreshMs 60000


### PR DESCRIPTION
... to comform with our [guidelines][1].

[1]: https://github.com/mozilla-services/dockerflow#dockerfile-requirements

This may make parts of the data on the physical volume inaccessible when deployed to the dev environment. In stage, I will simply delete the physical volume and regenerate it from scratch. If this causes too much trouble, we can discuss alternatives, e.g. adding `chmod -R app:app /persistent` temporarily to fix the data.