### PR TITLE
Remove the read-only Kinto client from the publisher.

### DIFF
--- a/moz_kinto_publisher/main.py
+++ b/moz_kinto_publisher/main.py
@@ -276,9 +276,7 @@ def main():
             )
         )
 
-    log.info(
-        f"Connecting... RW={settings.KINTO_RW_SERVER_URL}"
-    )
+    log.info(f"Connecting... RW={settings.KINTO_RW_SERVER_URL}")
 
     rw_client = PublisherClient(
         server_url=settings.KINTO_RW_SERVER_URL,

--- a/moz_kinto_publisher/settings.py
+++ b/moz_kinto_publisher/settings.py
@@ -3,9 +3,6 @@ from decouple import config
 KINTO_RW_SERVER_URL = config(
     "KINTO_RW_SERVER_URL", default="https://settings-writer.stage.mozaws.net/v1/"
 )
-KINTO_RO_SERVER_URL = config(
-    "KINTO_RO_SERVER_URL", default="https://settings.stage.mozaws.net/v1/"
-)
 KINTO_AUTH_USER = config("KINTO_AUTH_USER", default="")
 KINTO_AUTH_PASSWORD = config("KINTO_AUTH_PASSWORD", default="")
 KINTO_AUTH_TOKEN = config("KINTO_AUTH_TOKEN", default="")


### PR DESCRIPTION
The security-state-staging collection is not supposed to be publicly accessible. For some reason we haven't figured out yet, it currently is [publicly accessible in prod](https://bugzilla.mozilla.org/show_bug.cgi?id=1668535), and it used to be publicly accessible in stage until recently. At least for now, the correct way to read that collection is an authenticated read on the Remote Settings writer instance.

CC @sciurus