### PR TITLE
Docker login before build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ commands:
         type: string
 
     steps:
+      - docker/check
       - run:
           name: Generate version.json
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,9 @@ jobs:
     docker:
       # specify the version
       - image: circleci/golang:1.13
+        auth:
+          username: ${DOCKER_LOGIN}
+          password: ${DOCKER_PASSWORD}
 
 
     working_directory: /go/src/github.com/mozilla.com/crlite
@@ -146,6 +149,9 @@ jobs:
   deploy-to-gke:
     docker:
       - image: 'cimg/base:stable'
+        auth:
+          username: ${DOCKER_LOGIN}
+          password: ${DOCKER_PASSWORD}
     steps:
       - gcp-gke/update-kubeconfig-with-credentials:
           cluster: ${GKE_CLUSTER_ID}


### PR DESCRIPTION
Beginning 2020-11-2 Docker Hub is rate limiting anonymous image pulls per IP address. This will impact our jobs that run on CircleCI. So let's login first every time we're talking to Docker. We already do that for the publish task, but we should on the build as well.
