### PR TITLE
Make the Kinto Publisher check that signatures are needed before requesting signatures

### DIFF
--- a/moz_kinto_publisher/main.py
+++ b/moz_kinto_publisher/main.py
@@ -156,7 +156,7 @@ class PublisherClient(Client):
                 + f"{response.content.decode('utf-8')}"
             )
 
-    def collection_needs_review(self, *, collection=None):
+    def collection_check_state(self, *, collection=None, state):
         collectionEnd = "buckets/{}/collections/{}".format(
             self._bucket_name, collection or self._collection_name
         )
@@ -171,8 +171,18 @@ class PublisherClient(Client):
             )
 
         status = response.json()["data"]["status"]
-        log.debug(f"Collection review status: {status}")
-        return status == "work-in-progress"
+        log.debug(
+            f"Collection review status: {status}, expecting {state} ({status==state})"
+        )
+        return status == state
+
+    def collection_needs_review(self, *, collection=None):
+        return self.collection_check_state(
+            collection=collection, state="work-in-progress"
+        )
+
+    def collection_needs_sign(self, *, collection=None):
+        return self.collection_check_state(collection=collection, state="to-review")
 
     def request_review_of_collection(self, *, collection=None):
         if not self.collection_needs_review(collection=collection):
@@ -1290,6 +1300,11 @@ def crlite_sign(*, args, rw_client):
     log.info(f"Signing collection {settings.KINTO_CRLITE_COLLECTION}, noop={args.noop}")
     if args.noop:
         return
+    if not rw_client.collection_needs_sign(collection=settings.KINTO_CRLITE_COLLECTION):
+        log.info(
+            f"Collection {settings.KINTO_CRLITE_COLLECTION} does not need a signature."
+        )
+        return
     rw_client.sign_collection(collection=settings.KINTO_CRLITE_COLLECTION)
 
 
@@ -1298,6 +1313,10 @@ def intermediates_sign(*, args, rw_client):
         f"Signing collection {settings.KINTO_INTERMEDIATES_COLLECTION}, noop={args.noop}"
     )
     if args.noop:
+        return
+    if not rw_client.collection_needs_sign(
+        collection=settings.KINTO_INTERMEDIATES_COLLECTION
+    ):
         return
     rw_client.sign_collection(collection=settings.KINTO_INTERMEDIATES_COLLECTION)
 

--- a/moz_kinto_publisher/main.py
+++ b/moz_kinto_publisher/main.py
@@ -204,6 +204,10 @@ class PublisherClient(Client):
             )
 
     def sign_collection(self, *, collection=None):
+        if not self.collection_needs_sign(collection=collection):
+            log.info("Collection does not require sign. Skipping.")
+            return
+
         collectionEnd = "buckets/{}/collections/{}".format(
             self._bucket_name, collection or self._collection_name
         )
@@ -1300,11 +1304,6 @@ def crlite_sign(*, args, rw_client):
     log.info(f"Signing collection {settings.KINTO_CRLITE_COLLECTION}, noop={args.noop}")
     if args.noop:
         return
-    if not rw_client.collection_needs_sign(collection=settings.KINTO_CRLITE_COLLECTION):
-        log.info(
-            f"Collection {settings.KINTO_CRLITE_COLLECTION} does not need a signature."
-        )
-        return
     rw_client.sign_collection(collection=settings.KINTO_CRLITE_COLLECTION)
 
 
@@ -1313,10 +1312,6 @@ def intermediates_sign(*, args, rw_client):
         f"Signing collection {settings.KINTO_INTERMEDIATES_COLLECTION}, noop={args.noop}"
     )
     if args.noop:
-        return
-    if not rw_client.collection_needs_sign(
-        collection=settings.KINTO_INTERMEDIATES_COLLECTION
-    ):
         return
     rw_client.sign_collection(collection=settings.KINTO_INTERMEDIATES_COLLECTION)
 


### PR DESCRIPTION
As it was, the `crlite_sign` and `intermediates_sign` methods always signed when
called, so every time the k8s job ran to sign, the signer actually did work.
This change is to check the state of the collection to be `"to-review"` before
requesting a signature.

Since I don't have a kinto-signer instance working locally, this was tested on
stage by manipulating the crlite records and rolling it back when done.

Fixes #140