### PR TITLE
Version bump the moz_crlite_query tool to 0.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         "google-cloud-storage",
         "kinto-http>=9.1",
         "moz_crlite_lib>=0.2",
-        "moz_crlite_query>=0.3.8",
+        "moz_crlite_query>=0.4.0",
         "progressbar2>=3.40",
         "psutil>=5",
         "pyOpenSSL>=17.5",


### PR DESCRIPTION
[moz_crlite_query v0.4.0](https://github.com/mozilla/moz_crlite_query/releases/tag/v0.4.0) handles certificates with leading zeroes, which could lead to false failures at the signer task.

This is pushed to dev as 7170ab1