### PR TITLE
Redefine enrollment to be 'all CRLs have to be valid'

### DIFF
--- a/go/cmd/aggregate-crls/aggregate-crls.go
+++ b/go/cmd/aggregate-crls/aggregate-crls.go
@@ -169,7 +169,7 @@ func (ae *AggregateEngine) crlFetchWorkerProcessOne(ctx context.Context, crlUrl 
 
 	if age > allowableAgeOfLocalCRL {
 		ae.auditor.Old(&issuer, &crlUrl, age)
-		glog.Warningf("[%s] CRL appears very old. Age: %s", crlUrl.String(), age)
+		glog.Warningf("[%s] CRL appears not very fresh, but proceeding with expiration check. Age: %s", crlUrl.String(), age)
 	}
 
 	glog.Infof("[%s] Updated CRL %s (path=%s) (sz=%d) (age=%s)", issuer.ID(), crlUrl.String(),

--- a/go/cmd/aggregate-crls/aggregate-crls_test.go
+++ b/go/cmd/aggregate-crls/aggregate-crls_test.go
@@ -122,7 +122,7 @@ func Test_loadAndCheckSignatureOfCRL(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	list, err := loadAndCheckSignatureOfCRL(crlPath.Name(), ca)
+	list, sha256sum, err := loadAndCheckSignatureOfCRL(crlPath.Name(), ca)
 	if err != nil {
 		t.Error(err)
 	}
@@ -135,8 +135,12 @@ func Test_loadAndCheckSignatureOfCRL(t *testing.T) {
 		t.Error("This Update didn't match")
 	}
 
+	if len(sha256sum) != 32 {
+		t.Error("Expected a 32-byte sha256 digest")
+	}
+
 	otherCa, _ := makeCA(t)
-	_, err = loadAndCheckSignatureOfCRL(crlPath.Name(), otherCa)
+	_, _, err = loadAndCheckSignatureOfCRL(crlPath.Name(), otherCa)
 	if !strings.Contains(err.Error(), "verification failure") {
 		t.Error(err)
 	}

--- a/go/cmd/aggregate-crls/aggregate-crls_test.go
+++ b/go/cmd/aggregate-crls/aggregate-crls_test.go
@@ -338,14 +338,6 @@ func Test_crlFetchWorker(t *testing.T) {
 	if result.Issuer.ID() != issuer.ID() {
 		t.Error("Unexpected issuer")
 	}
-	if len(result.CrlUrlPaths) != 0 {
-		t.Errorf("Unexpected CRLs: %+v", result.CrlUrlPaths)
-	}
-
-	result = <-resultChan
-	if result.Issuer.ID() != issuer.ID() {
-		t.Error("Unexpected issuer")
-	}
 	if len(result.CrlUrlPaths) != 1 {
 		t.Errorf("Unexpected CRLs: %+v", result.CrlUrlPaths)
 	}
@@ -355,6 +347,14 @@ func Test_crlFetchWorker(t *testing.T) {
 		t.Error("Unexpected issuer")
 	}
 	if len(result.CrlUrlPaths) != 2 {
+		t.Errorf("Unexpected CRLs: %+v", result.CrlUrlPaths)
+	}
+
+	result = <-resultChan
+	if result.Issuer.ID() != issuer.ID() {
+		t.Error("Unexpected issuer")
+	}
+	if len(result.CrlUrlPaths) != 3 {
 		t.Errorf("Unexpected CRLs: %+v", result.CrlUrlPaths)
 	}
 

--- a/go/cmd/aggregate-crls/aggregate-crls_test.go
+++ b/go/cmd/aggregate-crls/aggregate-crls_test.go
@@ -285,7 +285,7 @@ func Test_crlFetchWorker(t *testing.T) {
 	bar := display.AddBar(1)
 
 	urlChan := make(chan types.IssuerCrlUrls, 16)
-	resultChan := make(chan types.IssuerCrlPaths, 16)
+	resultChan := make(chan types.IssuerCrlUrlPaths, 16)
 
 	ca, caPrivKey := makeCA(t)
 	issuer := issuersObj.InsertIssuerFromCertAndPem(ca, "")
@@ -330,32 +330,32 @@ func Test_crlFetchWorker(t *testing.T) {
 	if result.Issuer.ID() != issuer.ID() {
 		t.Error("Unexpected issuer")
 	}
-	if len(result.CrlPaths) != 0 {
-		t.Errorf("Unexpected CRLs: %+v", result.CrlPaths)
+	if len(result.CrlUrlPaths) != 0 {
+		t.Errorf("Unexpected CRLs: %+v", result.CrlUrlPaths)
 	}
 
 	result = <-resultChan
 	if result.Issuer.ID() != issuer.ID() {
 		t.Error("Unexpected issuer")
 	}
-	if len(result.CrlPaths) != 0 {
-		t.Errorf("Unexpected CRLs: %+v", result.CrlPaths)
+	if len(result.CrlUrlPaths) != 0 {
+		t.Errorf("Unexpected CRLs: %+v", result.CrlUrlPaths)
 	}
 
 	result = <-resultChan
 	if result.Issuer.ID() != issuer.ID() {
 		t.Error("Unexpected issuer")
 	}
-	if len(result.CrlPaths) != 1 {
-		t.Errorf("Unexpected CRLs: %+v", result.CrlPaths)
+	if len(result.CrlUrlPaths) != 1 {
+		t.Errorf("Unexpected CRLs: %+v", result.CrlUrlPaths)
 	}
 
 	result = <-resultChan
 	if result.Issuer.ID() != issuer.ID() {
 		t.Error("Unexpected issuer")
 	}
-	if len(result.CrlPaths) != 2 {
-		t.Errorf("Unexpected CRLs: %+v", result.CrlPaths)
+	if len(result.CrlUrlPaths) != 2 {
+		t.Errorf("Unexpected CRLs: %+v", result.CrlUrlPaths)
 	}
 
 	select {

--- a/go/cmd/aggregate-crls/crl-auditor.go
+++ b/go/cmd/aggregate-crls/crl-auditor.go
@@ -21,7 +21,7 @@ var (
 	AuditKindFailedVerify       CrlAuditEntryKind = "Failed Verify"
 	AuditKindOlderThanLast      CrlAuditEntryKind = "Older Than Previous"
 	AuditKindNoRevocations      CrlAuditEntryKind = "Empty Revocation List"
-	AuditKindOld                CrlAuditEntryKind = "Very Old, Warning"
+	AuditKindOld                CrlAuditEntryKind = "Not Fresh, Warning"
 	AuditKindExpired            CrlAuditEntryKind = "Expired, Allowed"
 	AuditKindValid              CrlAuditEntryKind = "Valid, Processed"
 )

--- a/go/cmd/aggregate-crls/crl-auditor.go
+++ b/go/cmd/aggregate-crls/crl-auditor.go
@@ -21,7 +21,7 @@ var (
 	AuditKindFailedVerify       CrlAuditEntryKind = "Failed Verify"
 	AuditKindOlderThanLast      CrlAuditEntryKind = "Older Than Previous"
 	AuditKindNoRevocations      CrlAuditEntryKind = "Empty Revocation List"
-	AuditKindOld                CrlAuditEntryKind = "Very Old, Blocked"
+	AuditKindOld                CrlAuditEntryKind = "Very Old, Warning"
 	AuditKindExpired            CrlAuditEntryKind = "Expired, Allowed"
 	AuditKindValid              CrlAuditEntryKind = "Valid, Processed"
 )

--- a/go/cmd/aggregate-crls/crl-auditor.go
+++ b/go/cmd/aggregate-crls/crl-auditor.go
@@ -155,26 +155,28 @@ func (auditor *CrlAuditor) Expired(issuer downloader.DownloadIdentifier, crlUrl 
 	})
 }
 
-func (auditor *CrlAuditor) FailedVerifyPath(issuer downloader.DownloadIdentifier, crlPath string, err error) {
+func (auditor *CrlAuditor) FailedVerifyPath(issuer downloader.DownloadIdentifier, crlUrl *url.URL, crlPath string, err error) {
 	auditor.mutex.Lock()
 	defer auditor.mutex.Unlock()
 
 	auditor.Entries = append(auditor.Entries, CrlAuditEntry{
 		Timestamp:     time.Now().UTC(),
 		Kind:          AuditKindFailedVerify,
+		Url:           crlUrl.String(),
 		Path:          crlPath,
 		Issuer:        issuer,
 		IssuerSubject: auditor.getSubject(issuer),
 		Errors:        []string{err.Error()},
 	})
 }
-func (auditor *CrlAuditor) FailedProcessLocal(issuer downloader.DownloadIdentifier, crlPath string, err error) {
+func (auditor *CrlAuditor) FailedProcessLocal(issuer downloader.DownloadIdentifier, crlUrl *url.URL, crlPath string, err error) {
 	auditor.mutex.Lock()
 	defer auditor.mutex.Unlock()
 
 	auditor.Entries = append(auditor.Entries, CrlAuditEntry{
 		Timestamp:     time.Now().UTC(),
 		Kind:          AuditKindFailedProcessLocal,
+		Url:           crlUrl.String(),
 		Path:          crlPath,
 		Issuer:        issuer,
 		IssuerSubject: auditor.getSubject(issuer),
@@ -182,26 +184,28 @@ func (auditor *CrlAuditor) FailedProcessLocal(issuer downloader.DownloadIdentifi
 	})
 }
 
-func (auditor *CrlAuditor) NoRevocations(issuer downloader.DownloadIdentifier, crlPath string) {
+func (auditor *CrlAuditor) NoRevocations(issuer downloader.DownloadIdentifier, crlUrl *url.URL, crlPath string) {
 	auditor.mutex.Lock()
 	defer auditor.mutex.Unlock()
 
 	auditor.Entries = append(auditor.Entries, CrlAuditEntry{
 		Timestamp:     time.Now().UTC(),
 		Kind:          AuditKindNoRevocations,
+		Url:           crlUrl.String(),
 		Path:          crlPath,
 		Issuer:        issuer,
 		IssuerSubject: auditor.getSubject(issuer),
 	})
 }
 
-func (auditor *CrlAuditor) ValidAndProcessed(issuer downloader.DownloadIdentifier, crlPath string, numRevocations int, age time.Duration, sha256 []byte) {
+func (auditor *CrlAuditor) ValidAndProcessed(issuer downloader.DownloadIdentifier, crlUrl *url.URL, crlPath string, numRevocations int, age time.Duration, sha256 []byte) {
 	auditor.mutex.Lock()
 	defer auditor.mutex.Unlock()
 
 	auditor.Entries = append(auditor.Entries, CrlAuditEntry{
 		Timestamp:      time.Now().UTC(),
 		Kind:           AuditKindValid,
+		Url:            crlUrl.String(),
 		Path:           crlPath,
 		Issuer:         issuer,
 		IssuerSubject:  auditor.getSubject(issuer),

--- a/go/cmd/aggregate-crls/crl-auditor_test.go
+++ b/go/cmd/aggregate-crls/crl-auditor_test.go
@@ -85,11 +85,14 @@ func assertEntryUrlAndIssuer(t *testing.T, ent *CrlAuditEntry, issuer storage.Is
 	assertValidEntry(t, ent)
 }
 
-func assertEntryPathAndIssuer(t *testing.T, ent *CrlAuditEntry, issuer storage.Issuer,
-	issuersObj *rootprogram.MozIssuers, path string) {
+func assertEntryUrlPathAndIssuer(t *testing.T, ent *CrlAuditEntry, issuer storage.Issuer,
+	issuersObj *rootprogram.MozIssuers, url *url.URL, path string) {
 	t.Helper()
 	if ent.Path != path {
 		t.Errorf("Expected Path of %v got %v", path, ent.Path)
+	}
+	if ent.Url != url.String() {
+		t.Errorf("Expected URL of %v got %v", url, ent.Url)
 	}
 	if ent.Issuer.ID() != issuer.ID() {
 		t.Errorf("Expected Issuer of %v got %v", issuer, ent.Issuer)
@@ -192,13 +195,14 @@ func Test_FailedProcessLocal(t *testing.T) {
 	auditor := NewCrlAuditor(issuersObj)
 	issuer := issuersObj.NewTestIssuerFromSubjectString("Test Corporation SA")
 	path := "crls/crl.pem"
+	url, _ := url.Parse("http://test/crl")
 
 	assertEmptyList(t, auditor)
 
-	auditor.FailedProcessLocal(&issuer, path, fmt.Errorf("bad error"))
+	auditor.FailedProcessLocal(&issuer, url, path, fmt.Errorf("bad error"))
 
 	ent := assertOnlyEntryInList(t, auditor, AuditKindFailedProcessLocal)
-	assertEntryPathAndIssuer(t, ent, issuer, issuersObj, path)
+	assertEntryUrlPathAndIssuer(t, ent, issuer, issuersObj, url, path)
 }
 
 func Test_FailedVerifyLocal(t *testing.T) {
@@ -206,13 +210,14 @@ func Test_FailedVerifyLocal(t *testing.T) {
 	auditor := NewCrlAuditor(issuersObj)
 	issuer := issuersObj.NewTestIssuerFromSubjectString("Test Corporation SA")
 	path := "crls/crl.pem"
+	url, _ := url.Parse("http://test/crl")
 
 	assertEmptyList(t, auditor)
 
-	auditor.FailedVerifyPath(&issuer, path, fmt.Errorf("bad error"))
+	auditor.FailedVerifyPath(&issuer, url, path, fmt.Errorf("bad error"))
 
 	ent := assertOnlyEntryInList(t, auditor, AuditKindFailedVerify)
-	assertEntryPathAndIssuer(t, ent, issuer, issuersObj, path)
+	assertEntryUrlPathAndIssuer(t, ent, issuer, issuersObj, url, path)
 }
 
 func Test_FailedNoRevocations(t *testing.T) {
@@ -220,13 +225,14 @@ func Test_FailedNoRevocations(t *testing.T) {
 	auditor := NewCrlAuditor(issuersObj)
 	issuer := issuersObj.NewTestIssuerFromSubjectString("Test Corporation SA")
 	path := "crls/crl.pem"
+	url, _ := url.Parse("http://test/crl")
 
 	assertEmptyList(t, auditor)
 
-	auditor.NoRevocations(&issuer, path)
+	auditor.NoRevocations(&issuer, url, path)
 
 	ent := assertOnlyEntryInList(t, auditor, AuditKindNoRevocations)
-	assertEntryPathAndIssuer(t, ent, issuer, issuersObj, path)
+	assertEntryUrlPathAndIssuer(t, ent, issuer, issuersObj, url, path)
 }
 
 func Test_FailedOld(t *testing.T) {
@@ -280,6 +286,7 @@ func Test_Valid(t *testing.T) {
 	issuersObj := rootprogram.NewMozillaIssuers()
 	auditor := NewCrlAuditor(issuersObj)
 	issuer := issuersObj.NewTestIssuerFromSubjectString("Test Corporation SA")
+	url, _ := url.Parse("http://test/crl")
 	path := "/var/tmp/issuer.crl"
 
 	assertEmptyList(t, auditor)
@@ -289,10 +296,10 @@ func Test_Valid(t *testing.T) {
 		t.Error(err)
 	}
 
-	auditor.ValidAndProcessed(&issuer, path, 42, age, []byte{0x42})
+	auditor.ValidAndProcessed(&issuer, url, path, 42, age, []byte{0x42})
 
 	ent := assertOnlyEntryInList(t, auditor, AuditKindValid)
-	assertEntryPathAndIssuer(t, ent, issuer, issuersObj, path)
+	assertEntryUrlPathAndIssuer(t, ent, issuer, issuersObj, url, path)
 }
 
 func Test_EmptyReport(t *testing.T) {
@@ -340,9 +347,9 @@ func Test_SeveralFailures(t *testing.T) {
 
 	path := "/var/tmp/issuer.crl"
 
-	auditor.NoRevocations(&issuer, path)
-	auditor.NoRevocations(&issuer, path)
-	auditor.NoRevocations(&issuer, path)
+	auditor.NoRevocations(&issuer, url, path)
+	auditor.NoRevocations(&issuer, url, path)
+	auditor.NoRevocations(&issuer, url, path)
 
 	if len(auditor.GetEntries()) != 6 {
 		t.Errorf("Expected 6 entries")
@@ -352,7 +359,7 @@ func Test_SeveralFailures(t *testing.T) {
 		if i < 3 {
 			assertEntryUrlAndIssuer(t, &e, issuer, issuersObj, url)
 		} else {
-			assertEntryPathAndIssuer(t, &e, issuer, issuersObj, path)
+			assertEntryUrlPathAndIssuer(t, &e, issuer, issuersObj, url, path)
 		}
 	}
 

--- a/go/downloader/download-auditor.go
+++ b/go/downloader/download-auditor.go
@@ -11,5 +11,5 @@ type DownloadIdentifier interface {
 type DownloadAuditor interface {
 	FailedDownload(identifier DownloadIdentifier, crlUrl *url.URL, dlTracer *DownloadTracer, err error)
 	FailedVerifyUrl(identifier DownloadIdentifier, crlUrl *url.URL, dlTracer *DownloadTracer, err error)
-	FailedVerifyPath(identifier DownloadIdentifier, crlPath string, err error)
+	FailedVerifyPath(identifier DownloadIdentifier, crlUrl *url.URL, crlPath string, err error)
 }

--- a/go/downloader/verifying-downloader_test.go
+++ b/go/downloader/verifying-downloader_test.go
@@ -39,7 +39,8 @@ func (ta *testAuditor) FailedDownload(issuer DownloadIdentifier, crlUrl *url.URL
 }
 func (ta *testAuditor) FailedVerifyUrl(issuer DownloadIdentifier, crlUrl *url.URL, dlTracer *DownloadTracer, err error) {
 }
-func (ta *testAuditor) FailedVerifyPath(issuer DownloadIdentifier, crlPath string, err error) {}
+func (ta *testAuditor) FailedVerifyPath(issuer DownloadIdentifier, crlUrl *url.URL, crlPath string, err error) {
+}
 
 func Test_NotFoundNotLocal(t *testing.T) {
 	ts := httptest.NewServer(http.NotFoundHandler())

--- a/go/rootprogram/issuers.go
+++ b/go/rootprogram/issuers.go
@@ -82,9 +82,9 @@ func (ta *loggingAuditor) FailedVerifyUrl(issuer downloader.DownloadIdentifier, 
 	dlTracer *downloader.DownloadTracer, err error) {
 	glog.Warningf("Failed verify of %s: %s", crlUrl.String(), err)
 }
-func (ta *loggingAuditor) FailedVerifyPath(issuer downloader.DownloadIdentifier, crlPath string,
+func (ta *loggingAuditor) FailedVerifyPath(issuer downloader.DownloadIdentifier, crlUrl *url.URL, crlPath string,
 	err error) {
-	glog.Warningf("Failed verify of %s: %s", crlPath, err)
+	glog.Warningf("Failed verify of %s (local: %s): %s", crlUrl.String(), crlPath, err)
 }
 
 type identifier struct{}

--- a/go/types.go
+++ b/go/types.go
@@ -37,10 +37,15 @@ type IssuerCrlUrls struct {
 	Urls   []url.URL
 }
 
-type IssuerCrlPaths struct {
-	Issuer   storage.Issuer
-	IssuerDN string
-	CrlPaths []string
+type UrlPath struct {
+	Url  url.URL
+	Path string
+}
+
+type IssuerCrlUrlPaths struct {
+	Issuer      storage.Issuer
+	IssuerDN    string
+	CrlUrlPaths []UrlPath
 }
 
 type TBSCertificateListWithRawSerials struct {


### PR DESCRIPTION
Fixes #145

Require all issuer CRLs to be valid and up-to-date to include that issuer in the enrolled list, instead of at least one CRL be valid.

To make this more easily verifiable, also emit information to `crl-audit.json` for all processed CRLs, and always include the URL at which a given CRL is canonically located, allowing auditing tools to verify the number of CRLs processed for each issuer, and the whole status for each canonical URL.

This will dramatically increase the size of the crl-audit JSON, but then again it was pretty small before. It shouldn't be significant, especially compared to the increased auditability.