### PR TITLE
concretize the CertDatabase interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ ENV/
 
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 problems
+
+# vim swap files
+.*.swp

--- a/containers/scripts/crlite-fetch.sh
+++ b/containers/scripts/crlite-fetch.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
 
-${crlite_bin:-~/go/bin}/ct-fetch -nobars -logtostderr -stderrthreshold=INFO
+${crlite_bin:-~/go/bin}/ct-fetch -logtostderr -stderrthreshold=INFO
 
 exit 0

--- a/go/cmd/aggregate-crls/aggregate-crls.go
+++ b/go/cmd/aggregate-crls/aggregate-crls.go
@@ -545,7 +545,7 @@ func checkPathArg(strObj string, confOptionName string, ctconfig *config.CTConfi
 func main() {
 	ctconfig.Init()
 	ctx, cancel := context.WithCancel(context.Background())
-	storageDB, remoteCache, _ := engine.GetConfiguredStorage(ctx, ctconfig)
+	storageDB, remoteCache := engine.GetConfiguredStorage(ctx, ctconfig)
 	defer glog.Flush()
 
 	checkPathArg(*revokedpath, "revokedpath", ctconfig)

--- a/go/cmd/aggregate-crls/aggregate-crls_test.go
+++ b/go/cmd/aggregate-crls/aggregate-crls_test.go
@@ -152,7 +152,7 @@ func Test_verifyCRL(t *testing.T) {
 	auditor := NewCrlAuditor(issuersObj)
 	issuer := issuersObj.NewTestIssuerFromSubjectString("Test Corporation SA")
 	url, _ := url.Parse("http://test/crl")
-	storageDB, _ := storage.NewFilesystemDatabase(storage.NewMockBackend(), storage.NewMockRemoteCache())
+	storageDB, _ := storage.NewFilesystemDatabase(storage.NewMockRemoteCache())
 	display := mpb.New(
 		mpb.WithOutput(ioutil.Discard),
 	)
@@ -270,7 +270,7 @@ func Test_crlFetchWorker(t *testing.T) {
 		mpb.WithOutput(ioutil.Discard),
 	)
 
-	storageDB, _ := storage.NewFilesystemDatabase(storage.NewMockBackend(), storage.NewMockRemoteCache())
+	storageDB, _ := storage.NewFilesystemDatabase(storage.NewMockRemoteCache())
 	issuersObj := rootprogram.NewMozillaIssuers()
 	auditor := NewCrlAuditor(issuersObj)
 
@@ -382,7 +382,7 @@ func Test_crlFetchWorkerProcessOne(t *testing.T) {
 		mpb.WithOutput(ioutil.Discard),
 	)
 
-	storageDB, _ := storage.NewFilesystemDatabase(storage.NewMockBackend(), storage.NewMockRemoteCache())
+	storageDB, _ := storage.NewFilesystemDatabase(storage.NewMockRemoteCache())
 	issuersObj := rootprogram.NewMozillaIssuers()
 	auditor := NewCrlAuditor(issuersObj)
 

--- a/go/cmd/aggregate-crls/aggregate-crls_test.go
+++ b/go/cmd/aggregate-crls/aggregate-crls_test.go
@@ -152,7 +152,7 @@ func Test_verifyCRL(t *testing.T) {
 	auditor := NewCrlAuditor(issuersObj)
 	issuer := issuersObj.NewTestIssuerFromSubjectString("Test Corporation SA")
 	url, _ := url.Parse("http://test/crl")
-	storageDB, _ := storage.NewFilesystemDatabase(storage.NewMockRemoteCache())
+	storageDB, _ := storage.NewCertDatabase(storage.NewMockRemoteCache())
 	display := mpb.New(
 		mpb.WithOutput(ioutil.Discard),
 	)
@@ -270,7 +270,7 @@ func Test_crlFetchWorker(t *testing.T) {
 		mpb.WithOutput(ioutil.Discard),
 	)
 
-	storageDB, _ := storage.NewFilesystemDatabase(storage.NewMockRemoteCache())
+	storageDB, _ := storage.NewCertDatabase(storage.NewMockRemoteCache())
 	issuersObj := rootprogram.NewMozillaIssuers()
 	auditor := NewCrlAuditor(issuersObj)
 
@@ -382,7 +382,7 @@ func Test_crlFetchWorkerProcessOne(t *testing.T) {
 		mpb.WithOutput(ioutil.Discard),
 	)
 
-	storageDB, _ := storage.NewFilesystemDatabase(storage.NewMockRemoteCache())
+	storageDB, _ := storage.NewCertDatabase(storage.NewMockRemoteCache())
 	issuersObj := rootprogram.NewMozillaIssuers()
 	auditor := NewCrlAuditor(issuersObj)
 

--- a/go/cmd/aggregate-known/aggregate-known.go
+++ b/go/cmd/aggregate-known/aggregate-known.go
@@ -112,7 +112,7 @@ func checkPathArg(strObj string, confOptionName string, ctconfig *config.CTConfi
 func main() {
 	ctconfig.Init()
 	ctx := context.Background()
-	storageDB, remoteCache, loadBackend := engine.GetConfiguredStorage(ctx, ctconfig)
+	storageDB, remoteCache := engine.GetConfiguredStorage(ctx, ctconfig)
 	defer glog.Flush()
 
 	checkPathArg(*enrolledpath, "enrolledpath", ctconfig)
@@ -227,7 +227,6 @@ func main() {
 	for t := 0; t < *ctconfig.NumThreads; t++ {
 		wg.Add(1)
 		worker := knownWorker{
-			loadStorage: loadBackend,
 			saveStorage: saveBackend,
 			progBar:     progressBar,
 			remoteCache: remoteCache,

--- a/go/cmd/ct-fetch/ct-fetch.go
+++ b/go/cmd/ct-fetch/ct-fetch.go
@@ -35,13 +35,10 @@ import (
 	"github.com/mozilla/crlite/go/config"
 	"github.com/mozilla/crlite/go/engine"
 	"github.com/mozilla/crlite/go/storage"
-	"github.com/vbauerster/mpb/v5"
-	//	"github.com/vbauerster/mpb/v5/decor"
 )
 
 var (
 	ctconfig = config.NewCTConfig()
-	nobars   = flag.Bool("nobars", false, "disable display of download bars")
 )
 
 func uint64Min(x, y uint64) uint64 {
@@ -263,7 +260,6 @@ type LogSyncEngine struct {
 	DownloaderWaitGroup *sync.WaitGroup
 	database            storage.CertDatabase
 	entryChan           chan CtLogEntry
-	display             *mpb.Progress
 	cancelTrigger       context.CancelFunc
 	lastUpdateTime      time.Time
 	lastUpdateMutex     *sync.RWMutex
@@ -296,25 +292,12 @@ func NewLogSyncEngine(db storage.CertDatabase) *LogSyncEngine {
 	if err != nil {
 		glog.Fatal(err)
 	}
-	glog.Infof("Progress bar refresh rate is every %s.\n", refreshDur.String())
-
-	var barOutput io.Writer = nil
-	if nobars != nil && !*nobars {
-		barOutput = os.Stdout
-	}
-
-	display := mpb.NewWithContext(ctx,
-		mpb.WithWaitGroup(twg),
-		mpb.WithRefreshRate(refreshDur),
-		mpb.WithOutput(barOutput),
-	)
 
 	return &LogSyncEngine{
 		ThreadWaitGroup:     twg,
 		DownloaderWaitGroup: new(sync.WaitGroup),
 		database:            db,
 		entryChan:           make(chan CtLogEntry, 1024*16),
-		display:             display,
 		cancelTrigger:       cancel,
 		lastUpdateTime:      time.Time{},
 		lastUpdateMutex:     &sync.RWMutex{},

--- a/go/cmd/ct-fetch/ct-fetch.go
+++ b/go/cmd/ct-fetch/ct-fetch.go
@@ -170,13 +170,6 @@ func (ld *LogSyncEngine) Stop() {
 	ld.display.Wait()
 }
 
-func (ld *LogSyncEngine) Cleanup() {
-	err := ld.database.Cleanup()
-	if err != nil {
-		glog.Errorf("Cache cleanup error caught: %s", err)
-	}
-}
-
 func (ld *LogSyncEngine) insertCTWorker() {
 	ld.ThreadWaitGroup.Add(1)
 	defer ld.ThreadWaitGroup.Done()
@@ -492,7 +485,7 @@ func main() {
 	ctx := context.Background()
 	rand.Seed(time.Now().UnixNano())
 
-	storageDB, _, _ := engine.GetConfiguredStorage(ctx, ctconfig)
+	storageDB, _ := engine.GetConfiguredStorage(ctx, ctconfig)
 	defer glog.Flush()
 
 	if ctconfig.IssuerCNFilter != nil && len(*ctconfig.IssuerCNFilter) > 0 {
@@ -617,7 +610,6 @@ func main() {
 		}()
 		syncEngine.Stop()                 // Stop workers
 		syncEngine.ThreadWaitGroup.Wait() // Wait for workers to stop
-		syncEngine.Cleanup()              // Ensure cache is coherent
 
 		if err := healthServer.Shutdown(ctx); err != nil {
 			glog.Infof("HTTP server shutdown error: %v", err)

--- a/go/cmd/ct-fetch/ct-fetch.go
+++ b/go/cmd/ct-fetch/ct-fetch.go
@@ -708,8 +708,8 @@ func (lw *LogWorker) downloadCTRangeToChannel(verifier *CtLogSubtreeVerifier, en
 
 	b := &backoff.Backoff{
 		Jitter: true,
-		Min:    500 * time.Millisecond,
-		Max:    5 * time.Minute,
+		Min:    5 * time.Second,
+		Max:    10 * time.Minute,
 	}
 
 	index := verifier.Subtree.First

--- a/go/cmd/ct-fetch/ct-fetch.go
+++ b/go/cmd/ct-fetch/ct-fetch.go
@@ -7,16 +7,19 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"crypto"
 	"flag"
 	"fmt"
 	"io"
-	"math"
+	"math/bits"
 	"math/rand"
 	"net/http"
 	"net/url"
 	"os"
 	"os/signal"
+	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -77,6 +80,167 @@ func uint64ToTimestamp(timestamp uint64) *time.Time {
 type CtLogEntry struct {
 	LogEntry *ct.LogEntry
 	LogURL   string
+}
+
+type CtLogSubtree struct {
+	Root  []byte
+	First uint64
+	Last  uint64
+}
+
+func (r *CtLogSubtree) Size() uint64 {
+	return r.Last - r.First + 1
+}
+
+func (r *CtLogSubtree) Midpoint() uint64 {
+	size := r.Size()
+	prevPow2 := uint64(0)
+	if size > 1 {
+		prevPow2 = 1 << (bits.Len64(size-1) - 1)
+	}
+	return r.First + prevPow2
+}
+
+func rfc6962LeafHash(leaf []byte) []byte {
+	// Specified in section 2.1 of RFC 6962
+	h := crypto.SHA256.New()
+	h.Write([]byte{0})
+	h.Write(leaf)
+	return h.Sum(nil)
+}
+
+func rfc6962PairHash(left, right []byte) []byte {
+	// Specified in section 2.1 of RFC 6962
+	h := crypto.SHA256.New()
+	h.Write([]byte{1})
+	h.Write(left)
+	h.Write(right)
+	return h.Sum(nil)
+}
+
+type CtLogSubtreeVerifier struct {
+	Subtree     CtLogSubtree
+	hashStack   [][]byte // Scratch space for computing tree hash
+	numConsumed uint64   // Number of leaves hashed into hashStack
+}
+
+func (v *CtLogSubtreeVerifier) Consume(leaf []byte) {
+	if v.numConsumed == 0 {
+		// The hash stack might need to store a full sibling path
+		v.hashStack = make([][]byte, 0, bits.Len64(v.Subtree.Size())+2)
+	}
+	// Push the new leaf hash, H(0 || leaf), onto the stack
+	v.hashStack = append(v.hashStack, rfc6962LeafHash(leaf))
+	v.numConsumed += 1
+
+	// Iteratively pop a pair of siblings off the stack and replace them
+	// by H(1 || Left || Right). The number of times we do this is equal
+	// to the height of the largest complete subtree that contains the leaf
+	// that we just consumed.
+	iter := bits.TrailingZeros64(v.numConsumed)
+	for iter > 0 {
+		n := len(v.hashStack) - 1
+		L := v.hashStack[n-1]
+		R := v.hashStack[n]
+		v.hashStack = v.hashStack[:n-1]
+		v.hashStack = append(v.hashStack, rfc6962PairHash(L, R))
+		iter -= 1
+	}
+}
+
+func (v *CtLogSubtreeVerifier) CheckClaim() error {
+	if len(v.Subtree.Root) != crypto.SHA256.Size() {
+		return fmt.Errorf("CtLogSubtreeVerifier: Claim has the wrong length.")
+	}
+	if v.numConsumed != v.Subtree.Size() {
+		return fmt.Errorf("CtLogSubtreeVerifier: Consumed %d leaves but needed %d.", v.numConsumed, v.Subtree.Size())
+	}
+	// Finish computing the Merkle tree head.
+	for len(v.hashStack) > 1 {
+		n := len(v.hashStack) - 1
+		L := v.hashStack[n-1]
+		R := v.hashStack[n]
+		v.hashStack = v.hashStack[:n-1]
+		v.hashStack = append(v.hashStack, rfc6962PairHash(L, R))
+	}
+	if bytes.Compare(v.Subtree.Root, v.hashStack[0]) != 0 {
+		return fmt.Errorf("CtLogSubtreeVerifier: Verification failed.")
+	}
+	return nil
+}
+
+func consistencyProofToSubtrees(proof [][]byte, oldSize, newSize uint64) ([]CtLogSubtree, error) {
+	// Annotates a consistency proof with the indices needed to check it.
+
+	if newSize <= oldSize {
+		return nil, fmt.Errorf("Empty proof")
+	}
+
+	terms := make([]CtLogSubtree, 0, bits.Len64(newSize)+2)
+
+	// A consistency proof between |oldSize| and |newSize| is
+	// "almost" an inclusion proof for index |oldSize|-1 in the tree
+	// of size |newSize|. "Almost" because we can omit terms from
+	// the old tree so long as we provide enough information to
+	// recover the old tree head.
+	//
+	// We represent the current node by the the set of leaves below
+	// it, so each internal node of the tree looks like:
+	//         [low, high]
+	//          /       \
+	// [low, mid-1]  [mid, high]
+	// (The value of mid is determined by the size of the [low, high]
+	// interval.)
+	//
+	// We will traverse from the root towards the leaf at index
+	// |oldSize|-1, and we will record the set of leaves that lie
+	// below the sibling of each node that we visit.
+	//
+	cursor := CtLogSubtree{First: uint64(0), Last: uint64(newSize - 1)}
+	target := uint64(oldSize - 1)
+
+	// We walk down the tree until we reach a leaf (low == high) or
+	// a node which is in the old tree (high <= target). Both conditions
+	// are necessary if we are to handle the |oldSize| = 0 case.
+	//
+	for cursor.First != cursor.Last && cursor.Last != target {
+		mid := cursor.Midpoint()
+		if target < mid {
+			terms = append(terms, CtLogSubtree{First: mid, Last: cursor.Last})
+			cursor.Last = mid - 1
+		} else {
+			terms = append(terms, CtLogSubtree{First: cursor.First, Last: mid - 1})
+			cursor.First = mid
+		}
+	}
+
+	// The cursor is at node [low, high] and we have just recorded
+	// this node's sibling. We need to record enough information to
+	// recover the old tree head. If |oldSize| is a power of two,
+	// then the current node is the old tree head and the caller
+	// already knows its value. Otherwise we need to record the
+	// current node so that the caller can recover the old tree
+	// head.
+	//
+	if (oldSize & (oldSize - 1)) != 0 { // 0 < |oldSize| is not a power of 2
+		terms = append(terms, cursor)
+	}
+
+	if len(terms) != len(proof) {
+		return nil, fmt.Errorf("Expected proof of length %d and got %d.",
+			len(terms), len(proof))
+	}
+
+	// Reverse the list to conform with the presentation from RFC 6962
+	for i, j := 0, len(terms)-1; i < j; i, j = i+1, j-1 {
+		terms[i], terms[j] = terms[j], terms[i]
+	}
+
+	for i := 0; i < len(proof); i++ {
+		terms[i].Root = proof[i]
+	}
+
+	return terms, nil
 }
 
 // Coordinates all workers
@@ -350,25 +514,71 @@ func (lw *LogWorker) Run(entryChan chan<- CtLogEntry) error {
 		return nil
 	}
 
-	finalIndex, finalTime, err := lw.downloadCTRangeToChannel(entryChan)
+	// We're given the indices of the leaves that we will download,
+	// but we also need the tree sizes.
+	oldSize := uint64(lw.StartPos)
+	newSize := uint64(lw.EndPos + 1)
+
+	// Fetch a consistency proof between |oldSize| and |newSize|.
+	// We won't verify this proof, as we might not have signed tree
+	// heads for the tree sizes. However, we will verify that the
+	// entries we download generate the corresponding entries in
+	// the proof.
+	proof, err := lw.Client.GetSTHConsistency(context.Background(), oldSize, newSize)
 	if err != nil {
-		lw.Bar.Abort(true)
-		glog.Errorf("[%s] downloadCTRangeToChannel exited with an error: %v, finalIndex=%d, finalTime=%s",
-			lw.LogURL, err, finalIndex, finalTime)
+		glog.Errorf("[%s] Unable to fetch consistency proof: %s", lw.LogURL, err)
+		return err
 	}
 
-	lw.saveState(finalIndex, finalTime)
+	subtrees, err := consistencyProofToSubtrees(proof, oldSize, newSize)
+	if err != nil {
+		glog.Errorf("[%s] Invalid proof: %s", lw.LogURL, err)
+		return err
+	}
+
+	verifiers := make([]CtLogSubtreeVerifier, 0, len(subtrees))
+	// We're updating towards the latest STH. We want a
+	// contiguous set of verified entries in the database.
+	// So subtrees should be downloaded and verified in
+	// order of increasing first element.
+	for _, subtree := range subtrees {
+		if subtree.First <= lw.LogState.MaxEntry {
+			continue
+		}
+		if subtree.First < lw.StartPos {
+			continue
+		}
+		pos := sort.Search(len(verifiers),
+			func(i int) bool {
+				return subtree.First < verifiers[i].Subtree.First
+			})
+		verifiers = append(verifiers[:pos],
+			append([]CtLogSubtreeVerifier{CtLogSubtreeVerifier{Subtree: subtree}},
+				verifiers[pos:]...)...)
+	}
+
+	for _, verifier := range verifiers {
+		finalIndex, finalTime, err := lw.downloadCTRangeToChannel(&verifier, entryChan)
+		if err != nil {
+			lw.Bar.Abort(true)
+			glog.Errorf("[%s] downloadCTRangeToChannel exited with an error: %v, finalIndex=%d, finalTime=%s",
+				lw.LogURL, err, finalIndex, finalTime)
+		}
+		err = verifier.CheckClaim()
+		if err != nil {
+			lw.Bar.Abort(true)
+			glog.Errorf("[%s] downloadCTRangeToChannel could not verify entries %d-%d: %s",
+				lw.LogURL, verifier.Subtree.First, verifier.Subtree.Last, err)
+		}
+		glog.Infof("[%s] %v == %v", lw.LogURL, verifier.Subtree.Root, verifier.hashStack[0])
+		lw.saveState(finalIndex, finalTime)
+	}
+
 	return err
 }
 
 func (lw *LogWorker) saveState(index uint64, entryTime *time.Time) {
-	if index > math.MaxInt64 {
-		glog.Errorf("[%s] Log final index overflows int64. This shouldn't happen: %+v.",
-			lw.LogURL, index)
-		return
-	}
-
-	lw.LogState.MaxEntry = int64(index)
+	lw.LogState.MaxEntry = index
 	if entryTime != nil {
 		lw.LogState.LastEntryTime = *entryTime
 	}
@@ -388,7 +598,7 @@ func (lw *LogWorker) saveState(index uint64, entryTime *time.Time) {
 // less than upTo. If status is not nil then status updates will be written to
 // it until the function is complete, when it will be closed. The log entries
 // are provided to an output channel.
-func (lw *LogWorker) downloadCTRangeToChannel(entryChan chan<- CtLogEntry) (uint64, *time.Time, error) {
+func (lw *LogWorker) downloadCTRangeToChannel(verifier *CtLogSubtreeVerifier, entryChan chan<- CtLogEntry) (uint64, *time.Time, error) {
 	ctx := context.Background()
 
 	sigChan := make(chan os.Signal, 1)
@@ -405,11 +615,11 @@ func (lw *LogWorker) downloadCTRangeToChannel(entryChan chan<- CtLogEntry) (uint
 		Max:    5 * time.Minute,
 	}
 
-	index := lw.StartPos
-	for index < lw.EndPos {
-		max := index + 1000
-		if max >= lw.EndPos {
-			max = lw.EndPos - 1
+	index := verifier.Subtree.First
+	for index <= verifier.Subtree.Last {
+		max := index + 1024
+		if max > verifier.Subtree.Last {
+			max = verifier.Subtree.Last
 		}
 
 		cycleTime = time.Now()
@@ -471,6 +681,9 @@ func (lw *LogWorker) downloadCTRangeToChannel(entryChan chan<- CtLogEntry) (uint
 					break entrySavedLoop // proceed
 				}
 			}
+
+			// Continue verifying the consistency proof
+			verifier.Consume(entry.LeafInput)
 
 			metrics.MeasureSince([]string{"LogWorker", "ProcessedEntry"}, cycleTime)
 			index++

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -27,8 +27,7 @@ type CTConfig struct {
 	IssuerCNFilter      *string
 	LogExpiredEntries   *bool
 	SavePeriod          *string
-	PollingDelayMean    *string
-	PollingDelayStdDev  *int
+	PollingDelay        *uint64
 	StatsRefreshPeriod  *string
 	OutputRefreshPeriod *string
 	Config              *string
@@ -139,8 +138,7 @@ func NewCTConfig() *CTConfig {
 		SavePeriod:          new(string),
 		OutputRefreshPeriod: new(string),
 		StatsRefreshPeriod:  new(string),
-		PollingDelayMean:    new(string),
-		PollingDelayStdDev:  new(int),
+		PollingDelay:        new(uint64),
 	}
 }
 
@@ -182,8 +180,7 @@ func (c *CTConfig) Init() {
 	confInt(c.NumThreads, section, "numThreads", 1)
 	confBool(c.LogExpiredEntries, section, "logExpiredEntries", false)
 	confBool(c.RunForever, section, "runForever", false)
-	confInt(c.PollingDelayStdDev, section, "pollingDelayStdDev", 10)
-	confString(c.PollingDelayMean, section, "pollingDelayMean", "10m")
+	confUint64(c.PollingDelay, section, "pollingDelay", 600)
 	confString(c.SavePeriod, section, "savePeriod", "15m")
 	confString(c.IssuerCNFilter, section, "issuerCNFilter", "")
 	confString(c.CertPath, section, "certPath", "")
@@ -220,9 +217,8 @@ func (c *CTConfig) Usage() {
 	fmt.Println("Options:")
 	fmt.Println("googleProjectId = Google Cloud Platform Project ID, used for stackdriver logging")
 	fmt.Println("issuerCNFilter = Prefixes to match for CNs for permitted issuers, comma delimited")
-	fmt.Println("runForever = Run forever, pausing `pollingDelay` between runs")
-	fmt.Println("pollingDelayMean = Wait a mean of this long between polls")
-	fmt.Println("pollingDelayStdDev = Use this standard deviation between polls")
+	fmt.Println("runForever = Run forever, pausing `pollingDelay` seconds between runs")
+	fmt.Println("pollingDelay= Wait time in seconds between polls. Jitter will be added.")
 	fmt.Println("logExpiredEntries = Add expired entries to the database")
 	fmt.Println("numThreads = Use this many threads for normal operations")
 	fmt.Println("savePeriod = Duration between state saves, e.g. 15m")

--- a/go/engine/engine.go
+++ b/go/engine/engine.go
@@ -30,7 +30,7 @@ func GetConfiguredStorage(ctx context.Context, ctconfig *config.CTConfig) (stora
 		glog.Fatalf("Unable to configure Redis cache for host %v", *ctconfig.RedisHost)
 	}
 
-	storageDB, err = storage.NewFilesystemDatabase(remoteCache)
+	storageDB, err = storage.NewCertDatabase(remoteCache)
 	if err != nil {
 		glog.Fatalf("Unable to construct cache-only DB: %v", err)
 	}

--- a/go/go.mod
+++ b/go/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/go-immutable-radix v1.1.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.1 // indirect
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
-	github.com/jpillora/backoff v1.0.0 // indirect
+	github.com/jpillora/backoff v1.0.0
 	github.com/onsi/ginkgo v1.10.2 // indirect
 	github.com/onsi/gomega v1.7.0 // indirect
 	github.com/smartystreets/assertions v1.0.1 // indirect

--- a/go/storage/certdatabase_test.go
+++ b/go/storage/certdatabase_test.go
@@ -60,12 +60,9 @@ EA==
 func getTestHarness(t *testing.T) (*MockBackend, *MockRemoteCache, CertDatabase) {
 	mockBackend := NewMockBackend()
 	mockCache := NewMockRemoteCache()
-	storageDB, err := NewFilesystemDatabase(mockCache)
+	storageDB, err := NewCertDatabase(mockCache)
 	if err != nil {
 		t.Fatalf("Can't find DB: %s", err.Error())
-	}
-	if storageDB == nil {
-		t.Fatalf("Can't find DB")
 	}
 	return mockBackend, mockCache, storageDB
 }
@@ -213,7 +210,7 @@ func Test_LogStateFirestoreBackend(t *testing.T) {
 
 func Test_LogStateNoopBackend(t *testing.T) {
 	mockCache := NewMockRemoteCache()
-	storageDB, err := NewFilesystemDatabase(mockCache)
+	storageDB, err := NewCertDatabase(mockCache)
 	if err != nil {
 		t.Error(err)
 	}

--- a/go/storage/certdatabase_test.go
+++ b/go/storage/certdatabase_test.go
@@ -173,7 +173,7 @@ func test_LogState(t *testing.T, cache RemoteCache, storageDB CertDatabase) {
 	if log.ShortURL != "log.ct/2019" {
 		t.Errorf("Unexpected ShortURL %s", log.ShortURL)
 	}
-	if log.MaxEntry != 0 || !log.LastEntryTime.IsZero() {
+	if log.MaxEntry != 0 || log.MaxTimestamp != 0 {
 		t.Errorf("Expected a blank log  %s", log.String())
 	}
 
@@ -198,7 +198,7 @@ func test_LogState(t *testing.T, cache RemoteCache, storageDB CertDatabase) {
 	if updatedLog.ShortURL != "log.ct/2019" {
 		t.Errorf("Unexpected ShortURL %s", updatedLog.ShortURL)
 	}
-	if updatedLog.MaxEntry != 9 || !updatedLog.LastEntryTime.IsZero() {
+	if updatedLog.MaxEntry != 9 || updatedLog.MaxTimestamp != 0 {
 		t.Errorf("Expected the MaxEntry to be 9 %s", updatedLog.String())
 	}
 }

--- a/go/storage/filesystemdatabase.go
+++ b/go/storage/filesystemdatabase.go
@@ -1,15 +1,10 @@
 package storage
 
 import (
-	"context"
-	"crypto/sha1"
-	"encoding/pem"
 	"fmt"
 	"net/url"
-	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/bluele/gcache"
 	"github.com/golang/glog"
@@ -17,17 +12,14 @@ import (
 )
 
 type FilesystemDatabase struct {
-	backend         StorageBackend
 	extCache        RemoteCache
 	knownCertsCache gcache.Cache
 	metaMutex       *sync.RWMutex
 	meta            map[string]*IssuerMetadata
 }
 
-func NewFilesystemDatabase(aBackend StorageBackend, aExtCache RemoteCache) (*FilesystemDatabase,
-	error) {
+func NewFilesystemDatabase(aExtCache RemoteCache) (*FilesystemDatabase, error) {
 	db := &FilesystemDatabase{
-		backend:         aBackend,
 		extCache:        aExtCache,
 		knownCertsCache: gcache.New(8 * 1024).ARC().Build(),
 		metaMutex:       &sync.RWMutex{},
@@ -99,27 +91,11 @@ func (db *FilesystemDatabase) GetIssuerAndDatesFromCache() ([]IssuerDate, error)
 	return issuerList, nil
 }
 
-func (db *FilesystemDatabase) ListExpirationDates(aNotBefore time.Time) ([]ExpDate, error) {
-	return db.backend.ListExpirationDates(context.Background(), aNotBefore)
-}
-
-func (db *FilesystemDatabase) ListIssuersForExpirationDate(expDate ExpDate) ([]Issuer, error) {
-	return db.backend.ListIssuersForExpirationDate(context.Background(), expDate)
-}
-
 func (db *FilesystemDatabase) SaveLogState(aLogObj *CertificateLog) error {
-	ctx, ctxCancel := context.WithCancel(context.Background())
-	defer ctxCancel()
-	err := db.extCache.StoreLogState(aLogObj)
-	if err != nil {
-		glog.Warningf("Couldn't store log state for %s: %s", aLogObj, err)
-	}
-	return db.backend.StoreLogState(ctx, aLogObj)
+	return db.extCache.StoreLogState(aLogObj)
 }
 
 func (db *FilesystemDatabase) GetLogState(aUrl *url.URL) (*CertificateLog, error) {
-	ctx, ctxCancel := context.WithCancel(context.Background())
-	defer ctxCancel()
 	shortUrl := fmt.Sprintf("%s%s", aUrl.Host, aUrl.Path)
 
 	log, cacheErr := db.extCache.LoadLogState(shortUrl)
@@ -127,32 +103,10 @@ func (db *FilesystemDatabase) GetLogState(aUrl *url.URL) (*CertificateLog, error
 		return log, cacheErr
 	}
 
-	log, backendErr := db.backend.LoadLogState(ctx, shortUrl)
-	if log != nil {
-		return log, backendErr
-	}
-
-	glog.Warningf("Allocating brand new log for %+v, cache err=%v, backend err=%v", shortUrl, cacheErr, backendErr)
+	glog.Warningf("Allocating brand new log for %+v, cache err=%v", shortUrl, cacheErr)
 	return &CertificateLog{
 		ShortURL: shortUrl,
 	}, nil
-}
-
-func (db *FilesystemDatabase) markDirty(aExpiration *time.Time) error {
-	subdirName := aExpiration.Format(kExpirationFormat)
-	return db.backend.MarkDirty(subdirName)
-}
-
-func getSpki(aCert *x509.Certificate) SPKI {
-	if len(aCert.SubjectKeyId) < 8 {
-		digest := sha1.Sum(aCert.RawSubjectPublicKeyInfo)
-
-		glog.V(2).Infof("[issuer: %s] SPKI is short: %v, using %v instead.",
-			aCert.Issuer.String(), aCert.SubjectKeyId, digest[0:])
-		return SPKI{digest[0:]}
-	}
-
-	return SPKI{aCert.SubjectKeyId}
 }
 
 func (db *FilesystemDatabase) Store(aCert *x509.Certificate, aIssuer *x509.Certificate,
@@ -161,53 +115,11 @@ func (db *FilesystemDatabase) Store(aCert *x509.Certificate, aIssuer *x509.Certi
 	issuer := NewIssuer(aIssuer)
 	knownCerts := db.GetKnownCertificates(expDate, issuer)
 
-	ctx, ctxCancel := context.WithCancel(context.Background())
-	defer ctxCancel()
-
-	headers := make(map[string]string)
-	headers["Log"] = aLogURL
-	headers["Recorded-at"] = time.Now().Format(time.RFC3339)
-	headers["Entry-id"] = strconv.FormatInt(aEntryId, 10)
-	pemblock := pem.Block{
-		Type:    "CERTIFICATE",
-		Headers: headers,
-		Bytes:   aCert.Raw,
-	}
-
 	serialNum := NewSerial(aCert)
 
-	certWasUnknown, err := knownCerts.WasUnknown(serialNum)
-	if err != nil {
-		return err
-	}
-
-	if certWasUnknown {
-		issuerDateSeenBefore, err := db.GetIssuerMetadata(issuer).Accumulate(aCert)
-		if err != nil {
-			return err
-		}
-		if !issuerDateSeenBefore {
-			// if the issuer/expdate was unknown in the cache
-			errAlloc := db.backend.AllocateExpDateAndIssuer(ctx, expDate, issuer)
-			if errAlloc != nil {
-				return errAlloc
-			}
-		}
-
-		errStore := db.backend.StoreCertificatePEM(ctx, serialNum, expDate, issuer,
-			pem.EncodeToMemory(&pemblock))
-		if errStore != nil {
-			return errStore
-		}
-	}
-
-	// Mark the directory dirty
-	err = db.markDirty(&aCert.NotAfter)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	// WasUnknown stores the certificate if it was unknown.
+	_, err := knownCerts.WasUnknown(serialNum)
+	return err
 }
 
 func (db *FilesystemDatabase) GetKnownCertificates(aExpDate ExpDate,
@@ -237,9 +149,4 @@ func (db *FilesystemDatabase) GetKnownCertificates(aExpDate ExpDate,
 		panic("kc is null")
 	}
 	return kc
-}
-
-func (db *FilesystemDatabase) Cleanup() error {
-	// TODO: Remove
-	return nil
 }

--- a/go/storage/issuermetadata_test.go
+++ b/go/storage/issuermetadata_test.go
@@ -105,21 +105,15 @@ func Test_Accumulate(t *testing.T) {
 	issuerObj := NewIssuer(firstCert)
 	meta := NewIssuerMetadata(issuerObj, NewMockRemoteCache())
 
-	seenBefore, err := meta.Accumulate(firstCert)
+	err := meta.Accumulate(firstCert)
 	if err != nil {
 		t.Error(err)
-	}
-	if seenBefore != false {
-		t.Error("Should have been a new day")
 	}
 
 	nextCert := makeCert(t, issuerCN, "2001-01-01", NewSerialFromHex("01"))
-	seenBefore, err = meta.Accumulate(nextCert)
+	err = meta.Accumulate(nextCert)
 	if err != nil {
 		t.Error(err)
-	}
-	if seenBefore != true {
-		t.Error("Should have not have been a new day")
 	}
 
 	if len(meta.CRLs()) != 0 {

--- a/go/storage/rediscache_test.go
+++ b/go/storage/rediscache_test.go
@@ -458,7 +458,7 @@ func TestRedisLogState(t *testing.T) {
 	log := &CertificateLog{
 		ShortURL:      "short_url/location",
 		MaxEntry:      123456789,
-		LastEntryTime: time.Time{},
+		MaxTimestamp:  time.Now().Unix(),
 	}
 
 	expectNilLogState(t, rc, log.ShortURL)

--- a/go/storage/rediscache_test.go
+++ b/go/storage/rediscache_test.go
@@ -458,7 +458,7 @@ func TestRedisLogState(t *testing.T) {
 	log := &CertificateLog{
 		ShortURL:     "short_url/location",
 		MaxEntry:     123456789,
-		MaxTimestamp: time.Now().Unix(),
+		MaxTimestamp: uint64(time.Now().Unix()),
 	}
 
 	expectNilLogState(t, rc, log.ShortURL)

--- a/go/storage/rediscache_test.go
+++ b/go/storage/rediscache_test.go
@@ -456,9 +456,9 @@ func TestRedisLogState(t *testing.T) {
 	defer rc.client.Del("log::short_url/location")
 
 	log := &CertificateLog{
-		ShortURL:      "short_url/location",
-		MaxEntry:      123456789,
-		MaxTimestamp:  time.Now().Unix(),
+		ShortURL:     "short_url/location",
+		MaxEntry:     123456789,
+		MaxTimestamp: time.Now().Unix(),
 	}
 
 	expectNilLogState(t, rc, log.ShortURL)

--- a/go/storage/storagebackend_tests.go
+++ b/go/storage/storagebackend_tests.go
@@ -62,7 +62,6 @@ func BackendTestListFiles(t *testing.T, db StorageBackend) {
 	if err != nil {
 		t.Fatalf("%s", err.Error())
 	}
-	// Normally the FilesystemDatabase object is responsible for this allocation
 	err = db.AllocateExpDateAndIssuer(context.TODO(), expDate, issuerObj)
 	if err != nil {
 		t.Fatal(err)
@@ -184,7 +183,6 @@ func BackendTestListingCertificates(t *testing.T, db StorageBackend) {
 				t.Fatalf("%s", err.Error())
 			}
 		}
-		// Normally the FilesystemDatabase object is responsible for this allocation
 		err := db.AllocateExpDateAndIssuer(context.TODO(), mkExpDate(date), issuer)
 		if err != nil {
 			t.Fatal(err)

--- a/go/storage/storagebackend_tests.go
+++ b/go/storage/storagebackend_tests.go
@@ -117,7 +117,7 @@ func BackendTestLogState(t *testing.T, db StorageBackend) {
 	if log.ShortURL != testLogURL {
 		t.Errorf("Unexpected URL %s", log.ShortURL)
 	}
-	if log.MaxEntry != 0 || !log.LastEntryTime.IsZero() {
+	if log.MaxEntry != 0 || log.MaxTimestamp != 0 {
 		t.Errorf("Expected a blank log  %s", log.String())
 	}
 
@@ -135,13 +135,13 @@ func BackendTestLogState(t *testing.T, db StorageBackend) {
 		if updatedLog.ShortURL != testLogURL {
 			t.Errorf("Unexpected URL %s", updatedLog.ShortURL)
 		}
-		if updatedLog.MaxEntry != 9 || !updatedLog.LastEntryTime.IsZero() {
+		if updatedLog.MaxEntry != 9 || updatedLog.MaxTimestamp != 0 {
 			t.Errorf("Expected the MaxEntry to be 9 and the time to be unset %s", updatedLog.String())
 		}
 	}
 
 	log.MaxEntry = 0xDEADBEEF
-	log.LastEntryTime = time.Unix(1567016306, 0)
+	log.MaxTimestamp = 1567016306
 	err = db.StoreLogState(context.TODO(), log)
 	if err != nil {
 		t.Errorf("Shouldn't have errored saving %v", err)
@@ -158,11 +158,11 @@ func BackendTestLogState(t *testing.T, db StorageBackend) {
 		if updatedLog.MaxEntry != 0xDEADBEEF {
 			t.Errorf("Expected the MaxEntry to be 0xDEADBEEF %s", updatedLog.String())
 		}
-		if updatedLog.LastEntryTime.IsZero() {
+		if updatedLog.MaxTimestamp == 0 {
 			t.Errorf("Expected the MaxEntry to be non-zero %s", updatedLog.String())
 		}
-		if updatedLog.LastEntryTime.Unix() != 1567016306 {
-			t.Errorf("Expected the LastEntryTime to be 1567016306. %s", updatedLog.String())
+		if updatedLog.MaxTimestamp != 1567016306 {
+			t.Errorf("Expected the MaxTimestamp to be 1567016306. %s", updatedLog.String())
 		}
 	}
 }

--- a/go/storage/types.go
+++ b/go/storage/types.go
@@ -68,13 +68,10 @@ type StorageBackend interface {
 }
 
 type CertDatabase interface {
-	Cleanup() error
 	SaveLogState(aLogObj *CertificateLog) error
 	GetLogState(url *url.URL) (*CertificateLog, error)
 	Store(aCert *x509.Certificate, aIssuer *x509.Certificate, aURL string,
 		aEntryId int64) error
-	ListExpirationDates(aNotBefore time.Time) ([]ExpDate, error)
-	ListIssuersForExpirationDate(expDate ExpDate) ([]Issuer, error)
 	GetKnownCertificates(aExpDate ExpDate, aIssuer Issuer) *KnownCertificates
 	GetIssuerMetadata(aIssuer Issuer) *IssuerMetadata
 	GetIssuerAndDatesFromCache() ([]IssuerDate, error)

--- a/go/storage/types.go
+++ b/go/storage/types.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
-	"net/url"
 	"strings"
 	"time"
 
@@ -65,16 +64,6 @@ type StorageBackend interface {
 		issuer Issuer) ([]Serial, error)
 	StreamSerialsForExpirationDateAndIssuer(ctx context.Context, expDate ExpDate,
 		issuer Issuer, quitChan <-chan struct{}, stream chan<- UniqueCertIdentifier) error
-}
-
-type CertDatabase interface {
-	SaveLogState(aLogObj *CertificateLog) error
-	GetLogState(url *url.URL) (*CertificateLog, error)
-	Store(aCert *x509.Certificate, aIssuer *x509.Certificate, aURL string,
-		aEntryId int64) error
-	GetKnownCertificates(aExpDate ExpDate, aIssuer Issuer) *KnownCertificates
-	GetIssuerMetadata(aIssuer Issuer) *IssuerMetadata
-	GetIssuerAndDatesFromCache() ([]IssuerDate, error)
 }
 
 type RemoteCache interface {

--- a/go/storage/types.go
+++ b/go/storage/types.go
@@ -23,14 +23,15 @@ const (
 
 type CertificateLog struct {
 	ShortURL       string    `db:"url"`            // URL to the log
-	MinEntry       uint64    `db:"minEntry"`       // The earliest entryID logged
-	MaxEntry       uint64    `db:"maxEntry"`       // The most recent entryID logged
+	MinEntry       uint64    `db:"minEntry"`       // The smallest index we've downloaded
+	MaxEntry       uint64    `db:"maxEntry"`       // The largest index we've downloaded
 	LastEntryTime  time.Time `db:"lastEntryTime"`  // Date of the most recently logged entry
 	LastUpdateTime time.Time `db:"lastUpdateTime"` // Date when we completed the last update
 }
 
 func (o *CertificateLog) String() string {
-	return fmt.Sprintf("[%s] MaxEntry=%d, LastEntryTime=%s LastUpdateTime=%s", o.ShortURL, o.MaxEntry, o.LastEntryTime, o.LastUpdateTime)
+	return fmt.Sprintf("[%s] MinEntry=%d MaxEntry=%d, LastEntryTime=%s LastUpdateTime=%s",
+		o.ShortURL, o.MinEntry, o.MaxEntry, o.LastEntryTime, o.LastUpdateTime)
 }
 
 func CertificateLogIDFromShortURL(shortURL string) string {

--- a/go/storage/types.go
+++ b/go/storage/types.go
@@ -31,7 +31,7 @@ type CertificateLog struct {
 }
 
 func (o *CertificateLog) String() string {
-	return fmt.Sprintf("[%s] MinEntry=%d MaxEntry=%d, MaxTimestamp=%s LastUpdateTime=%s",
+	return fmt.Sprintf("[%s] MinEntry=%d, MaxEntry=%d, MaxTimestamp=%d, LastUpdateTime=%s",
 		o.ShortURL, o.MinEntry, o.MaxEntry, o.MaxTimestamp, o.LastUpdateTime)
 }
 

--- a/go/storage/types.go
+++ b/go/storage/types.go
@@ -23,7 +23,8 @@ const (
 
 type CertificateLog struct {
 	ShortURL       string    `db:"url"`            // URL to the log
-	MaxEntry       int64     `db:"maxEntry"`       // The most recent entryID logged
+	MinEntry       uint64    `db:"minEntry"`       // The earliest entryID logged
+	MaxEntry       uint64    `db:"maxEntry"`       // The most recent entryID logged
 	LastEntryTime  time.Time `db:"lastEntryTime"`  // Date of the most recently logged entry
 	LastUpdateTime time.Time `db:"lastUpdateTime"` // Date when we completed the last update
 }

--- a/go/storage/types.go
+++ b/go/storage/types.go
@@ -25,13 +25,14 @@ type CertificateLog struct {
 	ShortURL       string    `db:"url"`            // URL to the log
 	MinEntry       uint64    `db:"minEntry"`       // The smallest index we've downloaded
 	MaxEntry       uint64    `db:"maxEntry"`       // The largest index we've downloaded
-	LastEntryTime  time.Time `db:"lastEntryTime"`  // Date of the most recently logged entry
+	MinTimestamp   uint64    `db:"minTimestamp"`   // Unix timestamp of the earliest entry we've downloaded
+	MaxTimestamp   uint64    `db:"maxTimestamp"`   // Unix timestamp of the most recent entry we've downloaded
 	LastUpdateTime time.Time `db:"lastUpdateTime"` // Date when we completed the last update
 }
 
 func (o *CertificateLog) String() string {
-	return fmt.Sprintf("[%s] MinEntry=%d MaxEntry=%d, LastEntryTime=%s LastUpdateTime=%s",
-		o.ShortURL, o.MinEntry, o.MaxEntry, o.LastEntryTime, o.LastUpdateTime)
+	return fmt.Sprintf("[%s] MinEntry=%d MaxEntry=%d, MaxTimestamp=%s LastUpdateTime=%s",
+		o.ShortURL, o.MinEntry, o.MaxEntry, o.MaxTimestamp, o.LastUpdateTime)
 }
 
 func CertificateLogIDFromShortURL(shortURL string) string {

--- a/go/storage/types_test.go
+++ b/go/storage/types_test.go
@@ -173,11 +173,11 @@ func TestLog(t *testing.T) {
 	log := CertificateLog{
 		ShortURL:       "log.example.com/2525",
 		MaxEntry:       math.MaxInt64,
-		LastEntryTime:  time.Date(2525, time.May, 20, 19, 21, 54, 39, time.UTC),
+		MaxTimestamp:   time.Date(2525, time.May, 20, 19, 21, 54, 39, time.UTC).Unix(),
 		LastUpdateTime: time.Date(3000, time.December, 31, 23, 55, 59, 0, time.UTC),
 	}
 
-	expectedString := "[log.example.com/2525] MaxEntry=9223372036854775807, LastEntryTime=2525-05-20 19:21:54.000000039 +0000 UTC LastUpdateTime=3000-12-31 23:55:59 +0000 UTC"
+	expectedString := "[log.example.com/2525] MaxEntry=9223372036854775807, MaxTimestamp=17526223314, LastUpdateTime=3000-12-31 23:55:59 +0000 UTC"
 	if log.String() != expectedString {
 		t.Errorf("Expecting %s but got %s", expectedString, log.String())
 	}
@@ -191,7 +191,7 @@ func TestLog(t *testing.T) {
 	log = CertificateLog{
 		ShortURL:      "yeti2021.ct.digicert.com/log/",
 		MaxEntry:      1517184,
-		LastEntryTime: time.Date(2019, time.August, 30, 05, 30, 16, 82, time.UTC),
+		MaxTimestamp:  time.Date(2019, time.August, 30, 05, 30, 16, 82, time.UTC).Unix(),
 	}
 
 	expectedID = "eWV0aTIwMjEuY3QuZGlnaWNlcnQuY29tL2xvZy8="

--- a/go/storage/types_test.go
+++ b/go/storage/types_test.go
@@ -173,11 +173,11 @@ func TestLog(t *testing.T) {
 	log := CertificateLog{
 		ShortURL:       "log.example.com/2525",
 		MaxEntry:       math.MaxInt64,
-		MaxTimestamp:   time.Date(2525, time.May, 20, 19, 21, 54, 39, time.UTC).Unix(),
+		MaxTimestamp:   uint64(time.Date(2525, time.May, 20, 19, 21, 54, 39, time.UTC).Unix()),
 		LastUpdateTime: time.Date(3000, time.December, 31, 23, 55, 59, 0, time.UTC),
 	}
 
-	expectedString := "[log.example.com/2525] MaxEntry=9223372036854775807, MaxTimestamp=17526223314, LastUpdateTime=3000-12-31 23:55:59 +0000 UTC"
+	expectedString := "[log.example.com/2525] MinEntry=0, MaxEntry=9223372036854775807, MaxTimestamp=17526223314, LastUpdateTime=3000-12-31 23:55:59 +0000 UTC"
 	if log.String() != expectedString {
 		t.Errorf("Expecting %s but got %s", expectedString, log.String())
 	}
@@ -191,7 +191,7 @@ func TestLog(t *testing.T) {
 	log = CertificateLog{
 		ShortURL:     "yeti2021.ct.digicert.com/log/",
 		MaxEntry:     1517184,
-		MaxTimestamp: time.Date(2019, time.August, 30, 05, 30, 16, 82, time.UTC).Unix(),
+		MaxTimestamp: uint64(time.Date(2019, time.August, 30, 05, 30, 16, 82, time.UTC).Unix()),
 	}
 
 	expectedID = "eWV0aTIwMjEuY3QuZGlnaWNlcnQuY29tL2xvZy8="

--- a/go/storage/types_test.go
+++ b/go/storage/types_test.go
@@ -189,9 +189,9 @@ func TestLog(t *testing.T) {
 
 	// From previous version
 	log = CertificateLog{
-		ShortURL:      "yeti2021.ct.digicert.com/log/",
-		MaxEntry:      1517184,
-		MaxTimestamp:  time.Date(2019, time.August, 30, 05, 30, 16, 82, time.UTC).Unix(),
+		ShortURL:     "yeti2021.ct.digicert.com/log/",
+		MaxEntry:     1517184,
+		MaxTimestamp: time.Date(2019, time.August, 30, 05, 30, 16, 82, time.UTC).Unix(),
 	}
 
 	expectedID = "eWV0aTIwMjEuY3QuZGlnaWNlcnQuY29tL2xvZy8="

--- a/moz_crlite_lib/moz_crlite_lib/__init__.py
+++ b/moz_crlite_lib/moz_crlite_lib/__init__.py
@@ -5,6 +5,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import base64
+import io
 import logging
 import os
 import struct
@@ -220,14 +221,10 @@ def save_additions(*, out_path, revoked_by_issuer):
 
 
 def expectRead(file, expectedBytes):
-    data = []
-    remaining = expectedBytes
-    while remaining > 0:
-        result = file.read(remaining)
-        if len(result) == 0:
-            raise EOFException()
-        remaining -= len(result)
-        data.extend(result)
+    assert isinstance(file, io.BufferedIOBase), "expectRead requires a buffered reader"
+    result = file.read(expectedBytes)
+    if len(result) < expectedBytes:
+        raise EOFException()
     return result
 
 

--- a/moz_crlite_lib/moz_crlite_lib/crlite_lib_test.py
+++ b/moz_crlite_lib/moz_crlite_lib/crlite_lib_test.py
@@ -1,4 +1,5 @@
 import base64
+import io
 import tempfile
 import unittest
 import moz_crlite_lib as crlite
@@ -6,7 +7,7 @@ import moz_crlite_lib as crlite
 from pathlib import Path
 
 
-class MockFile(object):
+class MockFile(io.BufferedIOBase):
     def __init__(self):
         self.data = b""
         self.idx = 0


### PR DESCRIPTION
This removes some unnecessary things from FilesystemDatabase and turns it into CertDatabase. The CertDatabase interface is not necessary.