### PR TITLE
Use new Remote Settings STAGE URL

### DIFF
--- a/containers/crlite-publish-config.properties.example
+++ b/containers/crlite-publish-config.properties.example
@@ -1,7 +1,7 @@
 # Be sure not to use quotes for strings in this file
 
 # Kinto information. RO and RW can be the same server, but don't have to be.
-KINTO_RO_SERVER_URL=https://settings.stage.mozaws.net/v1/
+KINTO_RO_SERVER_URL=https://settings-cdn.stage.mozaws.net/v1/
 KINTO_RW_SERVER_URL=https://settings-writer.stage.mozaws.net/v1/
 KINTO_AUTH_USER=kinto_publisher_example_user
 KINTO_AUTH_PASSWORD=kinto_publisher_example_password

--- a/containers/crlite-signoff-config.properties.example
+++ b/containers/crlite-signoff-config.properties.example
@@ -1,7 +1,7 @@
 # Be sure not to use quotes for strings in this file
 
 # Kinto information. RO and RW can be the same server, but don't have to be.
-KINTO_RO_SERVER_URL=https://settings.stage.mozaws.net/v1/
+KINTO_RO_SERVER_URL=https://settings-cdn.stage.mozaws.net/v1/
 KINTO_RW_SERVER_URL=https://settings-writer.stage.mozaws.net/v1/
 KINTO_AUTH_USER=kinto_signer_example_user
 KINTO_AUTH_PASSWORD=kinto_signer_example_password

--- a/containers/scripts/crlite-signoff-tool.py
+++ b/containers/scripts/crlite-signoff-tool.py
@@ -13,7 +13,7 @@ import sys
 import tempfile
 
 KINTO_RO_SERVER_URL = config(
-    "KINTO_RO_SERVER_URL", default="https://settings.stage.mozaws.net/v1/"
+    "KINTO_RO_SERVER_URL", default="https://settings-cdn.stage.mozaws.net/v1/"
 )
 KINTO_BUCKET = config("KINTO_BUCKET", default="security-state-preview")
 KINTO_CRLITE_COLLECTION = config("KINTO_CRLITE_COLLECTION", default="cert-revocations")

--- a/moz_kinto_publisher/settings.py
+++ b/moz_kinto_publisher/settings.py
@@ -4,7 +4,7 @@ KINTO_RW_SERVER_URL = config(
     "KINTO_RW_SERVER_URL", default="https://settings-writer.stage.mozaws.net/v1/"
 )
 KINTO_RO_SERVER_URL = config(
-    "KINTO_RO_SERVER_URL", default="https://settings.stage.mozaws.net/v1/"
+    "KINTO_RO_SERVER_URL", default="https://settings-cdn.stage.mozaws.net/v1/"
 )
 KINTO_AUTH_USER = config("KINTO_AUTH_USER", default="")
 KINTO_AUTH_PASSWORD = config("KINTO_AUTH_PASSWORD", default="")


### PR DESCRIPTION
In [Bug 1594573](https://bugzilla.mozilla.org/show_bug.cgi?id=1594573), we fixed some inconsistencies between our prod and stage URLs.

This is the new URL to be used for the STAGE public server.