### PR TITLE
Pin python cryptography library to version 3.4.8

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ verify_ssl = true
 
 [packages]
 bsdiff4 = ">=1.1"
-cryptography = ">=2.2"
+cryptography = "==3.4.8"
 dbx-stopwatch = ">=1.5"
 filtercascade = ">=0.1.3"
 glog = ">=0.3"

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     packages=["create_filter_cascade", "moz_kinto_publisher", "workflow"],
     install_requires=[
         "bsdiff4>=1.1",
-        "cryptography>=2.2",
+        "cryptography==3.4.8",
         "Deprecated>=1.2",
         "filtercascade>=0.3.1",
         "glog>=0.3",


### PR DESCRIPTION
Python cryptography version 35.0.0 cannot parse some certs in enrolled.json. I'll submit a test case upstream and open an issue here so that we release the pin when the issue is fixed.