### PR TITLE
Verify downloads against Merkle tree

### DIFF
--- a/go/storage/types.go
+++ b/go/storage/types.go
@@ -24,7 +24,8 @@ const (
 
 type CertificateLog struct {
 	ShortURL       string    `db:"url"`            // URL to the log
-	MaxEntry       int64     `db:"maxEntry"`       // The most recent entryID logged
+	MinEntry       uint64    `db:"minEntry"`       // The earliest entryID logged
+	MaxEntry       uint64    `db:"maxEntry"`       // The most recent entryID logged
 	LastEntryTime  time.Time `db:"lastEntryTime"`  // Date of the most recently logged entry
 	LastUpdateTime time.Time `db:"lastUpdateTime"` // Date when we completed the last update
 }


### PR DESCRIPTION
Verify that the entries we download match the entries in the log by checking the internal nodes of a consistency proof.

This is the first step toward resolving Issue #166. I've broken the work into several parts for review. The full stack is in my [issue 166 branch](https://github.com/jschanck/crlite/tree/issue.166).
