### PR TITLE
Issue #152: make it clear that expectRead needs a buffered reader

### DIFF
--- a/moz_crlite_lib/moz_crlite_lib/__init__.py
+++ b/moz_crlite_lib/moz_crlite_lib/__init__.py
@@ -5,6 +5,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import base64
+import io
 import logging
 import os
 import struct
@@ -220,14 +221,10 @@ def save_additions(*, out_path, revoked_by_issuer):
 
 
 def expectRead(file, expectedBytes):
-    data = []
-    remaining = expectedBytes
-    while remaining > 0:
-        result = file.read(remaining)
-        if len(result) == 0:
-            raise EOFException()
-        remaining -= len(result)
-        data.extend(result)
+    assert isinstance(file, io.BufferedIOBase), "expectRead requires a buffered reader"
+    result = file.read(expectedBytes)
+    if len(result) < expectedBytes:
+        raise EOFException()
     return result
 
 

--- a/moz_crlite_lib/moz_crlite_lib/crlite_lib_test.py
+++ b/moz_crlite_lib/moz_crlite_lib/crlite_lib_test.py
@@ -1,4 +1,5 @@
 import base64
+import io
 import tempfile
 import unittest
 import moz_crlite_lib as crlite
@@ -6,7 +7,7 @@ import moz_crlite_lib as crlite
 from pathlib import Path
 
 
-class MockFile(object):
+class MockFile(io.BufferedIOBase):
     def __init__(self):
         self.data = b""
         self.idx = 0


### PR DESCRIPTION
The `expectRead` implementation in moz_crlite_lib tries to handle short reads. This is unnecessary, as the behavior is already provided by file objects derived from python's BufferedIOBase class. Calls to "open" produce such file objects by default.

Resolves #152.