### PR TITLE
moz_kinto_publisher: Check that cert-revocation records have `attachment` field

### DIFF
--- a/moz_kinto_publisher/main.py
+++ b/moz_kinto_publisher/main.py
@@ -118,7 +118,7 @@ class PublisherClient(Client):
         mimeType="application/octet-stream",
         recordId=None,
     ):
-        if not (filePath ^ fileContents):
+        if not ((filePath is None) ^ (fileContents is None)):
             raise Exception("Must specify either filePath or fileContents")
 
         if filePath:

--- a/moz_kinto_publisher/main.py
+++ b/moz_kinto_publisher/main.py
@@ -743,7 +743,7 @@ def crlite_verify_record_consistency(*, existing_records):
         return
 
     for r in existing_records:
-        if not ("id" in r and "incremental" in r):
+        if not ("id" in r and "incremental" in r and "attachment" in r):
             raise ConsistencyException(f"Malformed record {r}.")
         if r["incremental"] and not "parent" in r:
             raise ConsistencyException(f"Malformed record {r}.")


### PR DESCRIPTION
Adds a consistency check to ensure that every record in the `cert-revocations` collection has an `attachment` field.

This PR also fixes a bug which caused an attachment field not to be created.