### PR TITLE
Part 1 of ct-fetch upgrade

### DIFF
--- a/containers/scripts/crlite-signoff-tool.py
+++ b/containers/scripts/crlite-signoff-tool.py
@@ -6,11 +6,11 @@ from pathlib import Path
 
 import argparse
 import hashlib
-import logging
 import requests
 import subprocess
 import sys
 import tempfile
+import glog as log
 
 KINTO_RO_SERVER_URL = config(
     "KINTO_RO_SERVER_URL", default="https://settings-cdn.stage.mozaws.net/v1/"
@@ -33,7 +33,6 @@ parser.add_argument(
 
 
 def main():
-    log = logging.getLogger("signoff-tool")
     args = parser.parse_args()
 
     headers = {"X-Automated-Tool": "https://github.com/mozilla/crlite"}
@@ -91,5 +90,4 @@ def main():
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO)
     main()

--- a/create_filter_cascade/certs_to_crlite.py
+++ b/create_filter_cascade/certs_to_crlite.py
@@ -7,12 +7,13 @@
 import argparse
 import itertools
 import json
-import logging
 import moz_crlite_lib as crlite
 import os
 import psutil
 import statsd
 import sys
+
+import glog as log
 
 from filtercascade import FilterCascade, fileformats
 from pathlib import Path
@@ -47,7 +48,6 @@ from pathlib import Path
 #   }
 # }
 
-log = logging.getLogger("cert_to_crlite")
 metrics = statsd.StatsClient(
     os.getenv("statsdHost", "localhost"),
     os.getenv("statsdPort", 8125),
@@ -429,5 +429,4 @@ def main():
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG)
     main()

--- a/create_filter_cascade/read_keys.py
+++ b/create_filter_cascade/read_keys.py
@@ -6,9 +6,9 @@
 
 import argparse
 import binascii
-import logging
 import moz_crlite_lib as crlite
 import sys
+import glog as log
 
 from collections import Counter
 from pathlib import Path
@@ -35,10 +35,10 @@ def read_keys(path, *, verbosity=0, serial=None):
             if serial and certId.serial == serial:
                 return certId
 
-    print(
+    log.info(
         f"Issuers: {len(issuers)} Most Common: {issuers.most_common(5)} Serials: {cnt}"
     )
-    print(
+    log.info(
         f"Issuer Lengths: {issuerLen.most_common(5)} Serial Lengths: {serialLen.most_common(5)}"
     )
 
@@ -71,15 +71,15 @@ def read_stash(path, *, verbosity=0, serial=None):
                 if serial and certId.serial == serial:
                     return certId
 
-    print(f"Issuers Affected: {cnt['issuers']}")
-    print(f"Number of New Revocations: {cnt['revocations']}")
+    log.info(f"Issuers Affected: {cnt['issuers']}")
+    log.info(f"Number of New Revocations: {cnt['revocations']}")
 
     totalBytes = 0
     for l, qty in serialLen.items():
         totalBytes += l * qty
-    print(f"Distribution of Serial Lengths: {serialLen.most_common(32)}")
-    print(f"Aggregated Serials in Bytes: {totalBytes} bytes")
-    print(f"Stash File Size in Bytes: {path.stat().st_size} bytes")
+    log.info(f"Distribution of Serial Lengths: {serialLen.most_common(32)}")
+    log.info(f"Aggregated Serials in Bytes: {totalBytes} bytes")
+    log.info(f"Stash File Size in Bytes: {path.stat().st_size} bytes")
 
     return False
 
@@ -115,5 +115,4 @@ def main():
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG)
     main()

--- a/go/cmd/ct-fetch/ct-fetch.go
+++ b/go/cmd/ct-fetch/ct-fetch.go
@@ -7,16 +7,19 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"crypto"
 	"flag"
 	"fmt"
 	"io"
-	"math"
+	"math/bits"
 	"math/rand"
 	"net/http"
 	"net/url"
 	"os"
 	"os/signal"
+	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -77,6 +80,167 @@ func uint64ToTimestamp(timestamp uint64) *time.Time {
 type CtLogEntry struct {
 	LogEntry *ct.LogEntry
 	LogURL   string
+}
+
+type CtLogSubtree struct {
+	Root  []byte
+	First uint64
+	Last  uint64
+}
+
+func (r *CtLogSubtree) Size() uint64 {
+	return r.Last - r.First + 1
+}
+
+func (r *CtLogSubtree) Midpoint() uint64 {
+	size := r.Size()
+	prevPow2 := uint64(0)
+	if size > 1 {
+		prevPow2 = 1 << (bits.Len64(size-1) - 1)
+	}
+	return r.First + prevPow2
+}
+
+func rfc6962LeafHash(leaf []byte) []byte {
+	// Specified in section 2.1 of RFC 6962
+	h := crypto.SHA256.New()
+	h.Write([]byte{0})
+	h.Write(leaf)
+	return h.Sum(nil)
+}
+
+func rfc6962PairHash(left, right []byte) []byte {
+	// Specified in section 2.1 of RFC 6962
+	h := crypto.SHA256.New()
+	h.Write([]byte{1})
+	h.Write(left)
+	h.Write(right)
+	return h.Sum(nil)
+}
+
+type CtLogSubtreeVerifier struct {
+	Subtree     CtLogSubtree
+	hashStack   [][]byte // Scratch space for computing tree hash
+	numConsumed uint64   // Number of leaves hashed into hashStack
+}
+
+func (v *CtLogSubtreeVerifier) Consume(leaf []byte) {
+	if v.numConsumed == 0 {
+		// The hash stack might need to store a full sibling path
+		v.hashStack = make([][]byte, 0, bits.Len64(v.Subtree.Size())+2)
+	}
+	// Push the new leaf hash, H(0 || leaf), onto the stack
+	v.hashStack = append(v.hashStack, rfc6962LeafHash(leaf))
+	v.numConsumed += 1
+
+	// Iteratively pop a pair of siblings off the stack and replace them
+	// by H(1 || Left || Right). The number of times we do this is equal
+	// to the height of the largest complete subtree that contains the leaf
+	// that we just consumed.
+	iter := bits.TrailingZeros64(v.numConsumed)
+	for iter > 0 {
+		n := len(v.hashStack) - 1
+		L := v.hashStack[n-1]
+		R := v.hashStack[n]
+		v.hashStack = v.hashStack[:n-1]
+		v.hashStack = append(v.hashStack, rfc6962PairHash(L, R))
+		iter -= 1
+	}
+}
+
+func (v *CtLogSubtreeVerifier) CheckClaim() error {
+	if len(v.Subtree.Root) != crypto.SHA256.Size() {
+		return fmt.Errorf("CtLogSubtreeVerifier: Claim has the wrong length.")
+	}
+	if v.numConsumed != v.Subtree.Size() {
+		return fmt.Errorf("CtLogSubtreeVerifier: Consumed %d leaves but needed %d.", v.numConsumed, v.Subtree.Size())
+	}
+	// Finish computing the Merkle tree head.
+	for len(v.hashStack) > 1 {
+		n := len(v.hashStack) - 1
+		L := v.hashStack[n-1]
+		R := v.hashStack[n]
+		v.hashStack = v.hashStack[:n-1]
+		v.hashStack = append(v.hashStack, rfc6962PairHash(L, R))
+	}
+	if bytes.Compare(v.Subtree.Root, v.hashStack[0]) != 0 {
+		return fmt.Errorf("CtLogSubtreeVerifier: Verification failed.")
+	}
+	return nil
+}
+
+func consistencyProofToSubtrees(proof [][]byte, oldSize, newSize uint64) ([]CtLogSubtree, error) {
+	// Annotates a consistency proof with the indices needed to check it.
+
+	if newSize <= oldSize {
+		return nil, fmt.Errorf("Empty proof")
+	}
+
+	terms := make([]CtLogSubtree, 0, bits.Len64(newSize)+2)
+
+	// A consistency proof between |oldSize| and |newSize| is
+	// "almost" an inclusion proof for index |oldSize|-1 in the tree
+	// of size |newSize|. "Almost" because we can omit terms from
+	// the old tree so long as we provide enough information to
+	// recover the old tree head.
+	//
+	// We represent the current node by the the set of leaves below
+	// it, so each internal node of the tree looks like:
+	//         [low, high]
+	//          /       \
+	// [low, mid-1]  [mid, high]
+	// (The value of mid is determined by the size of the [low, high]
+	// interval.)
+	//
+	// We will traverse from the root towards the leaf at index
+	// |oldSize|-1, and we will record the set of leaves that lie
+	// below the sibling of each node that we visit.
+	//
+	cursor := CtLogSubtree{First: uint64(0), Last: uint64(newSize - 1)}
+	target := uint64(oldSize - 1)
+
+	// We walk down the tree until we reach a leaf (low == high) or
+	// a node which is in the old tree (high <= target). Both conditions
+	// are necessary if we are to handle the |oldSize| = 0 case.
+	//
+	for cursor.First != cursor.Last && cursor.Last != target {
+		mid := cursor.Midpoint()
+		if target < mid {
+			terms = append(terms, CtLogSubtree{First: mid, Last: cursor.Last})
+			cursor.Last = mid - 1
+		} else {
+			terms = append(terms, CtLogSubtree{First: cursor.First, Last: mid - 1})
+			cursor.First = mid
+		}
+	}
+
+	// The cursor is at node [low, high] and we have just recorded
+	// this node's sibling. We need to record enough information to
+	// recover the old tree head. If |oldSize| is a power of two,
+	// then the current node is the old tree head and the caller
+	// already knows its value. Otherwise we need to record the
+	// current node so that the caller can recover the old tree
+	// head.
+	//
+	if (oldSize & (oldSize - 1)) != 0 { // 0 < |oldSize| is not a power of 2
+		terms = append(terms, cursor)
+	}
+
+	if len(terms) != len(proof) {
+		return nil, fmt.Errorf("Expected proof of length %d and got %d.",
+			len(terms), len(proof))
+	}
+
+	// Reverse the list to conform with the presentation from RFC 6962
+	for i, j := 0, len(terms)-1; i < j; i, j = i+1, j-1 {
+		terms[i], terms[j] = terms[j], terms[i]
+	}
+
+	for i := 0; i < len(proof); i++ {
+		terms[i].Root = proof[i]
+	}
+
+	return terms, nil
 }
 
 // Coordinates all workers
@@ -350,25 +514,71 @@ func (lw *LogWorker) Run(entryChan chan<- CtLogEntry) error {
 		return nil
 	}
 
-	finalIndex, finalTime, err := lw.downloadCTRangeToChannel(entryChan)
+	// We're given the indices of the leaves that we will download,
+	// but we also need the tree sizes.
+	oldSize := uint64(lw.StartPos)
+	newSize := uint64(lw.EndPos + 1)
+
+	// Fetch a consistency proof between |oldSize| and |newSize|.
+	// We won't verify this proof, as we might not have signed tree
+	// heads for the tree sizes. However, we will verify that the
+	// entries we download generate the corresponding entries in
+	// the proof.
+	proof, err := lw.Client.GetSTHConsistency(context.Background(), oldSize, newSize)
 	if err != nil {
-		lw.Bar.Abort(true)
-		glog.Errorf("[%s] downloadCTRangeToChannel exited with an error: %v, finalIndex=%d, finalTime=%s",
-			lw.LogURL, err, finalIndex, finalTime)
+		glog.Errorf("[%s] Unable to fetch consistency proof: %s", lw.LogURL, err)
+		return err
 	}
 
-	lw.saveState(finalIndex, finalTime)
+	subtrees, err := consistencyProofToSubtrees(proof, oldSize, newSize)
+	if err != nil {
+		glog.Errorf("[%s] Invalid proof: %s", lw.LogURL, err)
+		return err
+	}
+
+	verifiers := make([]CtLogSubtreeVerifier, 0, len(subtrees))
+	// We're updating towards the latest STH. We want a
+	// contiguous set of verified entries in the database.
+	// So subtrees should be downloaded and verified in
+	// order of increasing first element.
+	for _, subtree := range subtrees {
+		if subtree.First <= lw.LogState.MaxEntry {
+			continue
+		}
+		if subtree.First < lw.StartPos {
+			continue
+		}
+		pos := sort.Search(len(verifiers),
+			func(i int) bool {
+				return subtree.First < verifiers[i].Subtree.First
+			})
+		verifiers = append(verifiers[:pos],
+			append([]CtLogSubtreeVerifier{CtLogSubtreeVerifier{Subtree: subtree}},
+				verifiers[pos:]...)...)
+	}
+
+	for _, verifier := range verifiers {
+		finalIndex, finalTime, err := lw.downloadCTRangeToChannel(&verifier, entryChan)
+		if err != nil {
+			lw.Bar.Abort(true)
+			glog.Errorf("[%s] downloadCTRangeToChannel exited with an error: %v, finalIndex=%d, finalTime=%s",
+				lw.LogURL, err, finalIndex, finalTime)
+		}
+		err = verifier.CheckClaim()
+		if err != nil {
+			lw.Bar.Abort(true)
+			glog.Errorf("[%s] downloadCTRangeToChannel could not verify entries %d-%d: %s",
+				lw.LogURL, verifier.Subtree.First, verifier.Subtree.Last, err)
+		}
+		glog.Infof("[%s] %v == %v", lw.LogURL, verifier.Subtree.Root, verifier.hashStack[0])
+		lw.saveState(finalIndex, finalTime)
+	}
+
 	return err
 }
 
 func (lw *LogWorker) saveState(index uint64, entryTime *time.Time) {
-	if index > math.MaxInt64 {
-		glog.Errorf("[%s] Log final index overflows int64. This shouldn't happen: %+v.",
-			lw.LogURL, index)
-		return
-	}
-
-	lw.LogState.MaxEntry = int64(index)
+	lw.LogState.MaxEntry = index
 	if entryTime != nil {
 		lw.LogState.LastEntryTime = *entryTime
 	}
@@ -388,7 +598,7 @@ func (lw *LogWorker) saveState(index uint64, entryTime *time.Time) {
 // less than upTo. If status is not nil then status updates will be written to
 // it until the function is complete, when it will be closed. The log entries
 // are provided to an output channel.
-func (lw *LogWorker) downloadCTRangeToChannel(entryChan chan<- CtLogEntry) (uint64, *time.Time, error) {
+func (lw *LogWorker) downloadCTRangeToChannel(verifier *CtLogSubtreeVerifier, entryChan chan<- CtLogEntry) (uint64, *time.Time, error) {
 	ctx := context.Background()
 
 	sigChan := make(chan os.Signal, 1)
@@ -405,11 +615,11 @@ func (lw *LogWorker) downloadCTRangeToChannel(entryChan chan<- CtLogEntry) (uint
 		Max:    5 * time.Minute,
 	}
 
-	index := lw.StartPos
-	for index < lw.EndPos {
-		max := index + 1000
-		if max >= lw.EndPos {
-			max = lw.EndPos - 1
+	index := verifier.Subtree.First
+	for index <= verifier.Subtree.Last {
+		max := index + 1024
+		if max > verifier.Subtree.Last {
+			max = verifier.Subtree.Last
 		}
 
 		cycleTime = time.Now()
@@ -471,6 +681,9 @@ func (lw *LogWorker) downloadCTRangeToChannel(entryChan chan<- CtLogEntry) (uint
 					break entrySavedLoop // proceed
 				}
 			}
+
+			// Continue verifying the consistency proof
+			verifier.Consume(entry.LeafInput)
 
 			metrics.MeasureSince([]string{"LogWorker", "ProcessedEntry"}, cycleTime)
 			index++

--- a/go/storage/types.go
+++ b/go/storage/types.go
@@ -23,14 +23,15 @@ const (
 
 type CertificateLog struct {
 	ShortURL       string    `db:"url"`            // URL to the log
-	MinEntry       uint64    `db:"minEntry"`       // The earliest entryID logged
-	MaxEntry       uint64    `db:"maxEntry"`       // The most recent entryID logged
+	MinEntry       uint64    `db:"minEntry"`       // The smallest index we've downloaded
+	MaxEntry       uint64    `db:"maxEntry"`       // The largest index we've downloaded
 	LastEntryTime  time.Time `db:"lastEntryTime"`  // Date of the most recently logged entry
 	LastUpdateTime time.Time `db:"lastUpdateTime"` // Date when we completed the last update
 }
 
 func (o *CertificateLog) String() string {
-	return fmt.Sprintf("[%s] MaxEntry=%d, LastEntryTime=%s LastUpdateTime=%s", o.ShortURL, o.MaxEntry, o.LastEntryTime, o.LastUpdateTime)
+	return fmt.Sprintf("[%s] MinEntry=%d MaxEntry=%d, LastEntryTime=%s LastUpdateTime=%s",
+		o.ShortURL, o.MinEntry, o.MaxEntry, o.LastEntryTime, o.LastUpdateTime)
 }
 
 func CertificateLogIDFromShortURL(shortURL string) string {

--- a/go/storage/types.go
+++ b/go/storage/types.go
@@ -23,7 +23,8 @@ const (
 
 type CertificateLog struct {
 	ShortURL       string    `db:"url"`            // URL to the log
-	MaxEntry       int64     `db:"maxEntry"`       // The most recent entryID logged
+	MinEntry       uint64    `db:"minEntry"`       // The earliest entryID logged
+	MaxEntry       uint64    `db:"maxEntry"`       // The most recent entryID logged
 	LastEntryTime  time.Time `db:"lastEntryTime"`  // Date of the most recently logged entry
 	LastUpdateTime time.Time `db:"lastUpdateTime"` // Date when we completed the last update
 }

--- a/moz_crlite_lib/moz_crlite_lib/__init__.py
+++ b/moz_crlite_lib/moz_crlite_lib/__init__.py
@@ -6,13 +6,11 @@
 
 import base64
 import io
-import logging
 import os
 import struct
 
+import glog as log
 from pathlib import Path
-
-log = logging.getLogger("create_filter_cascade")
 
 # bytes 0-3: N, number of serials as an unsigned long
 # byte 4: L, length of issuer field as a unsigned char

--- a/moz_kinto_publisher/main.py
+++ b/moz_kinto_publisher/main.py
@@ -118,7 +118,7 @@ class PublisherClient(Client):
         mimeType="application/octet-stream",
         recordId=None,
     ):
-        if not (filePath ^ fileContents):
+        if not ((filePath is None) ^ (fileContents is None)):
             raise Exception("Must specify either filePath or fileContents")
 
         if filePath:

--- a/moz_kinto_publisher/main.py
+++ b/moz_kinto_publisher/main.py
@@ -743,7 +743,7 @@ def crlite_verify_record_consistency(*, existing_records):
         return
 
     for r in existing_records:
-        if not ("id" in r and "incremental" in r):
+        if not ("id" in r and "incremental" in r and "attachment" in r):
             raise ConsistencyException(f"Malformed record {r}.")
         if r["incremental"] and not "parent" in r:
             raise ConsistencyException(f"Malformed record {r}.")

--- a/workflow/1-generate_mlbf
+++ b/workflow/1-generate_mlbf
@@ -2,9 +2,9 @@
 
 from pathlib import Path
 from google.api_core import exceptions
+import glog as log
 
 import argparse
-import logging
 import os
 import subprocess
 import sys
@@ -20,7 +20,6 @@ parser.add_argument(
 
 
 def main():
-    log = logging.getLogger("generate_mlbf")
     args = parser.parse_args()
 
     if not args.identifier or len(args.identifier) != 1:
@@ -70,5 +69,4 @@ def main():
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO)
     main()

--- a/workflow/2-upload_artifacts_to_storage
+++ b/workflow/2-upload_artifacts_to_storage
@@ -8,7 +8,7 @@ from datetime import datetime
 import argparse
 import os
 import sys
-import logging
+import glog as log
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--noop", help="Don't upload", action="store_true")
@@ -24,9 +24,6 @@ parser.add_argument(
 parser.add_argument(
     "--filter-bucket", help="Google Cloud Storage filter bucket name", required=True
 )
-
-log = logging.getLogger("upload_artifacts_to_storage")
-
 
 @Retry(deadline=60)
 def uploadBlob(bucket, remoteFilePath, localFilePath):
@@ -103,5 +100,4 @@ def main():
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO)
     main()

--- a/workflow/__init__.py
+++ b/workflow/__init__.py
@@ -1,4 +1,4 @@
-import logging
+import glog as log
 import re
 import time
 from datetime import datetime, timedelta
@@ -6,8 +6,6 @@ from google.api_core import exceptions, page_iterator
 from google.cloud import storage
 
 kIdentifierFormat = re.compile(r"(\d{8}-\d+)/?")
-
-log = logging.getLogger("workflow")
 
 
 class FileNotFoundException(exceptions.NotFound):
@@ -86,7 +84,7 @@ def download_from_google_cloud(bucket_name, remote, local):
         raise FileNotFoundException(f"{remote} does not exist")
     with open(local, "wb") as file_obj:
         blob.download_to_file(file_obj)
-        logging.info(f"Downloaded {blob.public_url} to {local}")
+        log.info(f"Downloaded {blob.public_url} to {local}")
 
 
 def download_and_retry_from_google_cloud(


### PR DESCRIPTION
This PR makes two major changs to ct-fetch. First we verify the entries that we download against the internal nodes of the CT log's Merkle tree. This "check-summing" will ultimately let us import entries from a source other than the CT log itself. The second commit changes the order in which we download log entries. Reverse order is preferable if we're going to import a large cache of entries from a third party.