### PR TITLE
Part 3 of ct-fetch upgrade

### DIFF
--- a/go/config/config.go
+++ b/go/config/config.go
@@ -34,6 +34,7 @@ type CTConfig struct {
 	StatsDHost         *string
 	StatsDPort         *int
 	HealthAddr         *string
+	RemoteSettingsUpdateInterval *uint64
 }
 
 func confInt(p *int, section *ini.Section, key string, def int) {
@@ -139,6 +140,7 @@ func NewCTConfig() *CTConfig {
 		SavePeriod:         new(string),
 		StatsRefreshPeriod: new(string),
 		PollingDelay:       new(uint64),
+		RemoteSettingsUpdateInterval:       new(uint64),
 	}
 }
 
@@ -180,6 +182,7 @@ func (c *CTConfig) Init() {
 	confBool(c.LogExpiredEntries, section, "logExpiredEntries", false)
 	confBool(c.RunForever, section, "runForever", false)
 	confUint64(c.PollingDelay, section, "pollingDelay", 600)
+	confUint64(c.RemoteSettingsUpdateInterval, section, "remoteSettingsUpdateInterval", 60)
 	confString(c.SavePeriod, section, "savePeriod", "15m")
 	confString(c.IssuerCNFilter, section, "issuerCNFilter", "")
 	confString(c.CertPath, section, "certPath", "")

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -16,7 +16,7 @@ import (
 )
 
 type CTConfig struct {
-	LogUrlList         *string
+	CTLogMetadata      *string
 	CertPath           *string
 	GoogleProjectId    *string
 	RedisHost          *string
@@ -122,7 +122,7 @@ func confString(p *string, section *ini.Section, key string, def string) {
 func NewCTConfig() *CTConfig {
 	return &CTConfig{
 		BatchSize:          new(uint64),
-		LogUrlList:         new(string),
+		CTLogMetadata:      new(string),
 		NumThreads:         new(int),
 		LogExpiredEntries:  new(bool),
 		RunForever:         new(bool),
@@ -172,7 +172,7 @@ func (c *CTConfig) Init() {
 
 	// Fill in values, where conf file < env vars
 	confUint64(c.BatchSize, section, "batchSize", 4096)
-	confString(c.LogUrlList, section, "logList", "")
+	confString(c.CTLogMetadata, section, "ctLogMetadata", "")
 	confInt(c.NumThreads, section, "numThreads", 1)
 	confBool(c.LogExpiredEntries, section, "logExpiredEntries", false)
 	confBool(c.RunForever, section, "runForever", false)
@@ -207,6 +207,7 @@ func (c *CTConfig) Usage() {
 	fmt.Println("redisHost = address:port of the Redis instance")
 	fmt.Println("")
 	fmt.Println("Options:")
+	fmt.Println("ctLogMetadata = A string containing a JSON array of CTLogMetadata objects, for debugging")
 	fmt.Println("googleProjectId = Google Cloud Platform Project ID, used for stackdriver logging")
 	fmt.Println("issuerCNFilter = Prefixes to match for CNs for permitted issuers, comma delimited")
 	fmt.Println("runForever = Run forever, pausing `pollingDelay` seconds between runs")
@@ -214,7 +215,6 @@ func (c *CTConfig) Usage() {
 	fmt.Println("logExpiredEntries = Add expired entries to the database")
 	fmt.Println("numThreads = Use this many threads for normal operations")
 	fmt.Println("savePeriod = Duration between state saves, e.g. 15m")
-	fmt.Println("logList = URLs of the CT Logs, comma delimited")
 	fmt.Println("statsRefreshPeriod = Period between stats being dumped to stderr, only if statsdDhost and statsdPort are not set")
 	fmt.Println("statsdHost = host for StatsD information")
 	fmt.Println("statsdPort = port for StatsD information")

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -16,6 +16,7 @@ import (
 )
 
 type CTConfig struct {
+	RemoteSettingsURL  *string
 	CTLogMetadata      *string
 	CertPath           *string
 	GoogleProjectId    *string
@@ -122,6 +123,7 @@ func confString(p *string, section *ini.Section, key string, def string) {
 func NewCTConfig() *CTConfig {
 	return &CTConfig{
 		BatchSize:          new(uint64),
+		RemoteSettingsURL:  new(string),
 		CTLogMetadata:      new(string),
 		NumThreads:         new(int),
 		LogExpiredEntries:  new(bool),
@@ -172,6 +174,7 @@ func (c *CTConfig) Init() {
 
 	// Fill in values, where conf file < env vars
 	confUint64(c.BatchSize, section, "batchSize", 4096)
+	confString(c.RemoteSettingsURL, section, "remoteSettingsURL", "")
 	confString(c.CTLogMetadata, section, "ctLogMetadata", "")
 	confInt(c.NumThreads, section, "numThreads", 1)
 	confBool(c.LogExpiredEntries, section, "logExpiredEntries", false)
@@ -207,6 +210,7 @@ func (c *CTConfig) Usage() {
 	fmt.Println("redisHost = address:port of the Redis instance")
 	fmt.Println("")
 	fmt.Println("Options:")
+	fmt.Println("remoteSettingsURL = The base url for remote settings requests")
 	fmt.Println("ctLogMetadata = A string containing a JSON array of CTLogMetadata objects, for debugging")
 	fmt.Println("googleProjectId = Google Cloud Platform Project ID, used for stackdriver logging")
 	fmt.Println("issuerCNFilter = Prefixes to match for CNs for permitted issuers, comma delimited")

--- a/go/storage/types.go
+++ b/go/storage/types.go
@@ -22,6 +22,8 @@ const (
 )
 
 type CertificateLog struct {
+	LogID          string    `db:"logID"`          // The log's RFC 6962 LogID
+	MMD            uint64    `db:"mmd"`            // The log's maximum merge delay in seconds
 	ShortURL       string    `db:"url"`            // URL to the log
 	MinEntry       uint64    `db:"minEntry"`       // The smallest index we've downloaded
 	MaxEntry       uint64    `db:"maxEntry"`       // The largest index we've downloaded

--- a/go/types.go
+++ b/go/types.go
@@ -9,12 +9,12 @@ import (
 )
 
 type CTLogMetadata struct {
-	CRLiteEnrolled bool    `json:"crlite_enrolled"`
-	Description    string  `json:"description"`
-	Key            string  `json:"key"`
-	LogID          string  `json:"logID"`
-	MMD            int     `json:"mmd"`
-	URL            string  `json:"url"`
+	CRLiteEnrolled bool   `json:"crlite_enrolled"`
+	Description    string `json:"description"`
+	Key            string `json:"key"`
+	LogID          string `json:"logID"`
+	MMD            int    `json:"mmd"`
+	URL            string `json:"url"`
 }
 
 type IssuerCrlMap map[string]map[string]bool

--- a/go/types.go
+++ b/go/types.go
@@ -8,6 +8,15 @@ import (
 	"github.com/mozilla/crlite/go/storage"
 )
 
+type CTLogMetadata struct {
+	CRLiteEnrolled bool    `json:"crlite_enrolled"`
+	Description    string  `json:"description"`
+	Key            string  `json:"key"`
+	LogID          string  `json:"logID"`
+	MMD            int     `json:"mmd"`
+	URL            string  `json:"url"`
+}
+
 type IssuerCrlMap map[string]map[string]bool
 
 func (self IssuerCrlMap) Merge(other IssuerCrlMap) {


### PR DESCRIPTION
The first 8 commits are from parts 1 and 2. The rest allow us to configure the set of enrolled logs in remote settings.

* 255b189d070ca14c79c021539be002f3fa70c072 Replaces the URL parameter that we previously identified logs by with a collection of other metadata.
* 90550fb45b6610896924a905c3335f4470adf0c1 Saves more metadata about enrolled logs in redis. This metadata is read out by the aggregate jobs, which will be upgraded in a separate PR. 
* 34d2f764f293139e60c23f54458ec31a63a7c57c Loads the enrolled log list from remote settings, but only once at startup.
* adf288c3b2478225e88cc8da182bc6912ebff935 Adds support for periodically fetching the enrolled log list from remote settings.