### PR TITLE
Part 4 of ct-fetch upgrade

### DIFF
--- a/containers/scripts/crlite-fetch.sh
+++ b/containers/scripts/crlite-fetch.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
 
-${crlite_bin:-~/go/bin}/ct-fetch -nobars -logtostderr -stderrthreshold=INFO
+${crlite_bin:-~/go/bin}/ct-fetch -logtostderr -stderrthreshold=INFO
 
 exit 0

--- a/containers/scripts/crlite-generate.sh
+++ b/containers/scripts/crlite-generate.sh
@@ -21,11 +21,12 @@ ${crlite_bin:-~/go/bin}/aggregate-crls -crlpath ${crlite_persistent:-/ct}/crls \
               -enrolledpath ${ID}/enrolled.json \
               -auditpath ${ID}/crl-audit.json \
               -ccadb ${crlite_persistent:-/ct}/ccadb-intermediates.csv \
-              -nobars -alsologtostderr -log_dir ${ID}/log
+              -stderrthreshold=INFO -alsologtostderr \
+              -log_dir ${ID}/log
 
 ${crlite_bin:-~/go/bin}/aggregate-known -knownpath ${ID}/known \
               -enrolledpath ${ID}/enrolled.json \
-              -stderrthreshold=INFO -nobars -alsologtostderr \
+              -stderrthreshold=INFO -alsologtostderr \
               -log_dir ${WORKDIR}/log
 
 

--- a/go/cmd/aggregate-crls/aggregate-crls_test.go
+++ b/go/cmd/aggregate-crls/aggregate-crls_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/mozilla/crlite/go/downloader"
 	"github.com/mozilla/crlite/go/rootprogram"
 	"github.com/mozilla/crlite/go/storage"
-	"github.com/vbauerster/mpb/v5"
 )
 
 func Test_makeFilenameFromUrl(t *testing.T) {
@@ -153,16 +152,12 @@ func Test_verifyCRL(t *testing.T) {
 	issuer := issuersObj.NewTestIssuerFromSubjectString("Test Corporation SA")
 	url, _ := url.Parse("http://test/crl")
 	storageDB, _ := storage.NewCertDatabase(storage.NewMockRemoteCache())
-	display := mpb.New(
-		mpb.WithOutput(ioutil.Discard),
-	)
 
 	ae := AggregateEngine{
 		loadStorageDB: storageDB,
 		saveStorage:   storage.NewMockBackend(),
 		remoteCache:   storage.NewMockRemoteCache(),
 		issuers:       issuersObj,
-		display:       display,
 		auditor:       auditor,
 	}
 
@@ -266,10 +261,6 @@ func Test_crlFetchWorker(t *testing.T) {
 
 	var wg sync.WaitGroup
 
-	display := mpb.New(
-		mpb.WithOutput(ioutil.Discard),
-	)
-
 	storageDB, _ := storage.NewCertDatabase(storage.NewMockRemoteCache())
 	issuersObj := rootprogram.NewMozillaIssuers()
 	auditor := NewCrlAuditor(issuersObj)
@@ -279,10 +270,8 @@ func Test_crlFetchWorker(t *testing.T) {
 		saveStorage:   storage.NewMockBackend(),
 		remoteCache:   storage.NewMockRemoteCache(),
 		issuers:       issuersObj,
-		display:       display,
 		auditor:       auditor,
 	}
-	bar := display.AddBar(1)
 
 	urlChan := make(chan types.IssuerCrlUrls, 16)
 	resultChan := make(chan types.IssuerCrlUrlPaths, 16)
@@ -298,7 +287,7 @@ func Test_crlFetchWorker(t *testing.T) {
 	defer server.Close()
 
 	wg.Add(1)
-	go ae.crlFetchWorker(ctx, &wg, urlChan, resultChan, bar)
+	go ae.crlFetchWorker(ctx, &wg, urlChan, resultChan)
 
 	unavailableUrl, _ := url.Parse("http://localhost:1/file")
 	crl1Url, _ := url.Parse(server.URL + "/crl-1.crl")
@@ -378,10 +367,6 @@ func Test_crlFetchWorkerProcessOne(t *testing.T) {
 	*crlpath = tmpDir
 	defer os.RemoveAll(tmpDir)
 
-	display := mpb.New(
-		mpb.WithOutput(ioutil.Discard),
-	)
-
 	storageDB, _ := storage.NewCertDatabase(storage.NewMockRemoteCache())
 	issuersObj := rootprogram.NewMozillaIssuers()
 	auditor := NewCrlAuditor(issuersObj)
@@ -391,7 +376,6 @@ func Test_crlFetchWorkerProcessOne(t *testing.T) {
 		saveStorage:   storage.NewMockBackend(),
 		remoteCache:   storage.NewMockRemoteCache(),
 		issuers:       issuersObj,
-		display:       display,
 		auditor:       auditor,
 	}
 

--- a/go/cmd/ct-fetch/ct-fetch.go
+++ b/go/cmd/ct-fetch/ct-fetch.go
@@ -708,8 +708,8 @@ func (lw *LogWorker) downloadCTRangeToChannel(verifier *CtLogSubtreeVerifier, en
 
 	b := &backoff.Backoff{
 		Jitter: true,
-		Min:    500 * time.Millisecond,
-		Max:    5 * time.Minute,
+		Min:    5 * time.Second,
+		Max:    10 * time.Minute,
 	}
 
 	index := verifier.Subtree.First

--- a/go/cmd/ct-fetch/ct-fetch.go
+++ b/go/cmd/ct-fetch/ct-fetch.go
@@ -33,13 +33,10 @@ import (
 	"github.com/mozilla/crlite/go/config"
 	"github.com/mozilla/crlite/go/engine"
 	"github.com/mozilla/crlite/go/storage"
-	"github.com/vbauerster/mpb/v5"
-	//	"github.com/vbauerster/mpb/v5/decor"
 )
 
 var (
 	ctconfig = config.NewCTConfig()
-	nobars   = flag.Bool("nobars", false, "disable display of download bars")
 )
 
 func uint64Min(x, y uint64) uint64 {
@@ -261,7 +258,6 @@ type LogSyncEngine struct {
 	DownloaderWaitGroup *sync.WaitGroup
 	database            storage.CertDatabase
 	entryChan           chan CtLogEntry
-	display             *mpb.Progress
 	cancelTrigger       context.CancelFunc
 	lastUpdateTime      time.Time
 	lastUpdateMutex     *sync.RWMutex
@@ -291,17 +287,11 @@ func NewLogSyncEngine(db storage.CertDatabase) *LogSyncEngine {
 	_, cancel := context.WithCancel(context.Background())
 	twg := new(sync.WaitGroup)
 
-	refreshDur, err := time.ParseDuration(*ctconfig.OutputRefreshPeriod)
-	if err != nil {
-		glog.Fatal(err)
-	}
-
 	return &LogSyncEngine{
 		ThreadWaitGroup:     twg,
 		DownloaderWaitGroup: new(sync.WaitGroup),
 		database:            db,
 		entryChan:           make(chan CtLogEntry, 1024*16),
-		display:             display,
 		cancelTrigger:       cancel,
 		lastUpdateTime:      time.Time{},
 		lastUpdateMutex:     &sync.RWMutex{},

--- a/go/cmd/ct-fetch/ct-fetch.go
+++ b/go/cmd/ct-fetch/ct-fetch.go
@@ -7,16 +7,19 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"crypto"
 	"flag"
 	"fmt"
 	"io"
-	"math"
+	"math/bits"
 	"math/rand"
 	"net/http"
 	"net/url"
 	"os"
 	"os/signal"
+	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -77,6 +80,167 @@ func uint64ToTimestamp(timestamp uint64) *time.Time {
 type CtLogEntry struct {
 	LogEntry *ct.LogEntry
 	LogURL   string
+}
+
+type CtLogSubtree struct {
+	Root  []byte
+	First uint64
+	Last  uint64
+}
+
+func (r *CtLogSubtree) Size() uint64 {
+	return r.Last - r.First + 1
+}
+
+func (r *CtLogSubtree) Midpoint() uint64 {
+	size := r.Size()
+	prevPow2 := uint64(0)
+	if size > 1 {
+		prevPow2 = 1 << (bits.Len64(size-1) - 1)
+	}
+	return r.First + prevPow2
+}
+
+func rfc6962LeafHash(leaf []byte) []byte {
+	// Specified in section 2.1 of RFC 6962
+	h := crypto.SHA256.New()
+	h.Write([]byte{0})
+	h.Write(leaf)
+	return h.Sum(nil)
+}
+
+func rfc6962PairHash(left, right []byte) []byte {
+	// Specified in section 2.1 of RFC 6962
+	h := crypto.SHA256.New()
+	h.Write([]byte{1})
+	h.Write(left)
+	h.Write(right)
+	return h.Sum(nil)
+}
+
+type CtLogSubtreeVerifier struct {
+	Subtree     CtLogSubtree
+	hashStack   [][]byte // Scratch space for computing tree hash
+	numConsumed uint64   // Number of leaves hashed into hashStack
+}
+
+func (v *CtLogSubtreeVerifier) Consume(leaf []byte) {
+	if v.numConsumed == 0 {
+		// The hash stack might need to store a full sibling path
+		v.hashStack = make([][]byte, 0, bits.Len64(v.Subtree.Size())+2)
+	}
+	// Push the new leaf hash, H(0 || leaf), onto the stack
+	v.hashStack = append(v.hashStack, rfc6962LeafHash(leaf))
+	v.numConsumed += 1
+
+	// Iteratively pop a pair of siblings off the stack and replace them
+	// by H(1 || Left || Right). The number of times we do this is equal
+	// to the height of the largest complete subtree that contains the leaf
+	// that we just consumed.
+	iter := bits.TrailingZeros64(v.numConsumed)
+	for iter > 0 {
+		n := len(v.hashStack) - 1
+		L := v.hashStack[n-1]
+		R := v.hashStack[n]
+		v.hashStack = v.hashStack[:n-1]
+		v.hashStack = append(v.hashStack, rfc6962PairHash(L, R))
+		iter -= 1
+	}
+}
+
+func (v *CtLogSubtreeVerifier) CheckClaim() error {
+	if len(v.Subtree.Root) != crypto.SHA256.Size() {
+		return fmt.Errorf("CtLogSubtreeVerifier: Claim has the wrong length.")
+	}
+	if v.numConsumed != v.Subtree.Size() {
+		return fmt.Errorf("CtLogSubtreeVerifier: Consumed %d leaves but needed %d.", v.numConsumed, v.Subtree.Size())
+	}
+	// Finish computing the Merkle tree head.
+	for len(v.hashStack) > 1 {
+		n := len(v.hashStack) - 1
+		L := v.hashStack[n-1]
+		R := v.hashStack[n]
+		v.hashStack = v.hashStack[:n-1]
+		v.hashStack = append(v.hashStack, rfc6962PairHash(L, R))
+	}
+	if bytes.Compare(v.Subtree.Root, v.hashStack[0]) != 0 {
+		return fmt.Errorf("CtLogSubtreeVerifier: Verification failed.")
+	}
+	return nil
+}
+
+func consistencyProofToSubtrees(proof [][]byte, oldSize, newSize uint64) ([]CtLogSubtree, error) {
+	// Annotates a consistency proof with the indices needed to check it.
+
+	if newSize <= oldSize {
+		return nil, fmt.Errorf("Empty proof")
+	}
+
+	terms := make([]CtLogSubtree, 0, bits.Len64(newSize)+2)
+
+	// A consistency proof between |oldSize| and |newSize| is
+	// "almost" an inclusion proof for index |oldSize|-1 in the tree
+	// of size |newSize|. "Almost" because we can omit terms from
+	// the old tree so long as we provide enough information to
+	// recover the old tree head.
+	//
+	// We represent the current node by the the set of leaves below
+	// it, so each internal node of the tree looks like:
+	//         [low, high]
+	//          /       \
+	// [low, mid-1]  [mid, high]
+	// (The value of mid is determined by the size of the [low, high]
+	// interval.)
+	//
+	// We will traverse from the root towards the leaf at index
+	// |oldSize|-1, and we will record the set of leaves that lie
+	// below the sibling of each node that we visit.
+	//
+	cursor := CtLogSubtree{First: uint64(0), Last: uint64(newSize - 1)}
+	target := uint64(oldSize - 1)
+
+	// We walk down the tree until we reach a leaf (low == high) or
+	// a node which is in the old tree (high <= target). Both conditions
+	// are necessary if we are to handle the |oldSize| = 0 case.
+	//
+	for cursor.First != cursor.Last && cursor.Last != target {
+		mid := cursor.Midpoint()
+		if target < mid {
+			terms = append(terms, CtLogSubtree{First: mid, Last: cursor.Last})
+			cursor.Last = mid - 1
+		} else {
+			terms = append(terms, CtLogSubtree{First: cursor.First, Last: mid - 1})
+			cursor.First = mid
+		}
+	}
+
+	// The cursor is at node [low, high] and we have just recorded
+	// this node's sibling. We need to record enough information to
+	// recover the old tree head. If |oldSize| is a power of two,
+	// then the current node is the old tree head and the caller
+	// already knows its value. Otherwise we need to record the
+	// current node so that the caller can recover the old tree
+	// head.
+	//
+	if (oldSize & (oldSize - 1)) != 0 { // 0 < |oldSize| is not a power of 2
+		terms = append(terms, cursor)
+	}
+
+	if len(terms) != len(proof) {
+		return nil, fmt.Errorf("Expected proof of length %d and got %d.",
+			len(terms), len(proof))
+	}
+
+	// Reverse the list to conform with the presentation from RFC 6962
+	for i, j := 0, len(terms)-1; i < j; i, j = i+1, j-1 {
+		terms[i], terms[j] = terms[j], terms[i]
+	}
+
+	for i := 0; i < len(proof); i++ {
+		terms[i].Root = proof[i]
+	}
+
+	return terms, nil
 }
 
 // Coordinates all workers
@@ -350,25 +514,71 @@ func (lw *LogWorker) Run(entryChan chan<- CtLogEntry) error {
 		return nil
 	}
 
-	finalIndex, finalTime, err := lw.downloadCTRangeToChannel(entryChan)
+	// We're given the indices of the leaves that we will download,
+	// but we also need the tree sizes.
+	oldSize := uint64(lw.StartPos)
+	newSize := uint64(lw.EndPos + 1)
+
+	// Fetch a consistency proof between |oldSize| and |newSize|.
+	// We won't verify this proof, as we might not have signed tree
+	// heads for the tree sizes. However, we will verify that the
+	// entries we download generate the corresponding entries in
+	// the proof.
+	proof, err := lw.Client.GetSTHConsistency(context.Background(), oldSize, newSize)
 	if err != nil {
-		lw.Bar.Abort(true)
-		glog.Errorf("[%s] downloadCTRangeToChannel exited with an error: %v, finalIndex=%d, finalTime=%s",
-			lw.LogURL, err, finalIndex, finalTime)
+		glog.Errorf("[%s] Unable to fetch consistency proof: %s", lw.LogURL, err)
+		return err
 	}
 
-	lw.saveState(finalIndex, finalTime)
+	subtrees, err := consistencyProofToSubtrees(proof, oldSize, newSize)
+	if err != nil {
+		glog.Errorf("[%s] Invalid proof: %s", lw.LogURL, err)
+		return err
+	}
+
+	verifiers := make([]CtLogSubtreeVerifier, 0, len(subtrees))
+	// We're updating towards the latest STH. We want a
+	// contiguous set of verified entries in the database.
+	// So subtrees should be downloaded and verified in
+	// order of increasing first element.
+	for _, subtree := range subtrees {
+		if subtree.First <= lw.LogState.MaxEntry {
+			continue
+		}
+		if subtree.First < lw.StartPos {
+			continue
+		}
+		pos := sort.Search(len(verifiers),
+			func(i int) bool {
+				return subtree.First < verifiers[i].Subtree.First
+			})
+		verifiers = append(verifiers[:pos],
+			append([]CtLogSubtreeVerifier{CtLogSubtreeVerifier{Subtree: subtree}},
+				verifiers[pos:]...)...)
+	}
+
+	for _, verifier := range verifiers {
+		finalIndex, finalTime, err := lw.downloadCTRangeToChannel(&verifier, entryChan)
+		if err != nil {
+			lw.Bar.Abort(true)
+			glog.Errorf("[%s] downloadCTRangeToChannel exited with an error: %v, finalIndex=%d, finalTime=%s",
+				lw.LogURL, err, finalIndex, finalTime)
+		}
+		err = verifier.CheckClaim()
+		if err != nil {
+			lw.Bar.Abort(true)
+			glog.Errorf("[%s] downloadCTRangeToChannel could not verify entries %d-%d: %s",
+				lw.LogURL, verifier.Subtree.First, verifier.Subtree.Last, err)
+		}
+		glog.Infof("[%s] %v == %v", lw.LogURL, verifier.Subtree.Root, verifier.hashStack[0])
+		lw.saveState(finalIndex, finalTime)
+	}
+
 	return err
 }
 
 func (lw *LogWorker) saveState(index uint64, entryTime *time.Time) {
-	if index > math.MaxInt64 {
-		glog.Errorf("[%s] Log final index overflows int64. This shouldn't happen: %+v.",
-			lw.LogURL, index)
-		return
-	}
-
-	lw.LogState.MaxEntry = int64(index)
+	lw.LogState.MaxEntry = index
 	if entryTime != nil {
 		lw.LogState.LastEntryTime = *entryTime
 	}
@@ -388,7 +598,7 @@ func (lw *LogWorker) saveState(index uint64, entryTime *time.Time) {
 // less than upTo. If status is not nil then status updates will be written to
 // it until the function is complete, when it will be closed. The log entries
 // are provided to an output channel.
-func (lw *LogWorker) downloadCTRangeToChannel(entryChan chan<- CtLogEntry) (uint64, *time.Time, error) {
+func (lw *LogWorker) downloadCTRangeToChannel(verifier *CtLogSubtreeVerifier, entryChan chan<- CtLogEntry) (uint64, *time.Time, error) {
 	ctx := context.Background()
 
 	sigChan := make(chan os.Signal, 1)
@@ -405,11 +615,11 @@ func (lw *LogWorker) downloadCTRangeToChannel(entryChan chan<- CtLogEntry) (uint
 		Max:    5 * time.Minute,
 	}
 
-	index := lw.StartPos
-	for index < lw.EndPos {
-		max := index + 1000
-		if max >= lw.EndPos {
-			max = lw.EndPos - 1
+	index := verifier.Subtree.First
+	for index <= verifier.Subtree.Last {
+		max := index + 1024
+		if max > verifier.Subtree.Last {
+			max = verifier.Subtree.Last
 		}
 
 		cycleTime = time.Now()
@@ -471,6 +681,9 @@ func (lw *LogWorker) downloadCTRangeToChannel(entryChan chan<- CtLogEntry) (uint
 					break entrySavedLoop // proceed
 				}
 			}
+
+			// Continue verifying the consistency proof
+			verifier.Consume(entry.LeafInput)
 
 			metrics.MeasureSince([]string{"LogWorker", "ProcessedEntry"}, cycleTime)
 			index++

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -27,8 +27,7 @@ type CTConfig struct {
 	IssuerCNFilter      *string
 	LogExpiredEntries   *bool
 	SavePeriod          *string
-	PollingDelayMean    *string
-	PollingDelayStdDev  *int
+	PollingDelay        *uint64
 	StatsRefreshPeriod  *string
 	OutputRefreshPeriod *string
 	Config              *string
@@ -139,8 +138,7 @@ func NewCTConfig() *CTConfig {
 		SavePeriod:          new(string),
 		OutputRefreshPeriod: new(string),
 		StatsRefreshPeriod:  new(string),
-		PollingDelayMean:    new(string),
-		PollingDelayStdDev:  new(int),
+		PollingDelay:        new(uint64),
 	}
 }
 
@@ -182,8 +180,7 @@ func (c *CTConfig) Init() {
 	confInt(c.NumThreads, section, "numThreads", 1)
 	confBool(c.LogExpiredEntries, section, "logExpiredEntries", false)
 	confBool(c.RunForever, section, "runForever", false)
-	confInt(c.PollingDelayStdDev, section, "pollingDelayStdDev", 10)
-	confString(c.PollingDelayMean, section, "pollingDelayMean", "10m")
+	confUint64(c.PollingDelay, section, "pollingDelay", 600)
 	confString(c.SavePeriod, section, "savePeriod", "15m")
 	confString(c.IssuerCNFilter, section, "issuerCNFilter", "")
 	confString(c.CertPath, section, "certPath", "")
@@ -220,9 +217,8 @@ func (c *CTConfig) Usage() {
 	fmt.Println("Options:")
 	fmt.Println("googleProjectId = Google Cloud Platform Project ID, used for stackdriver logging")
 	fmt.Println("issuerCNFilter = Prefixes to match for CNs for permitted issuers, comma delimited")
-	fmt.Println("runForever = Run forever, pausing `pollingDelay` between runs")
-	fmt.Println("pollingDelayMean = Wait a mean of this long between polls")
-	fmt.Println("pollingDelayStdDev = Use this standard deviation between polls")
+	fmt.Println("runForever = Run forever, pausing `pollingDelay` seconds between runs")
+	fmt.Println("pollingDelay= Wait time in seconds between polls. Jitter will be added.")
 	fmt.Println("logExpiredEntries = Add expired entries to the database")
 	fmt.Println("numThreads = Use this many threads for normal operations")
 	fmt.Println("savePeriod = Duration between state saves, e.g. 15m")

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -16,23 +16,23 @@ import (
 )
 
 type CTConfig struct {
-	RemoteSettingsURL  *string
-	CTLogMetadata      *string
-	CertPath           *string
-	GoogleProjectId    *string
-	RedisHost          *string
-	RedisTimeout       *string
-	BatchSize          *uint64
-	NumThreads         *int
-	RunForever         *bool
-	LogExpiredEntries  *bool
-	SavePeriod         *string
-	PollingDelay       *uint64
-	StatsRefreshPeriod *string
-	Config             *string
-	StatsDHost         *string
-	StatsDPort         *int
-	HealthAddr         *string
+	RemoteSettingsURL            *string
+	CTLogMetadata                *string
+	CertPath                     *string
+	GoogleProjectId              *string
+	RedisHost                    *string
+	RedisTimeout                 *string
+	BatchSize                    *uint64
+	NumThreads                   *int
+	RunForever                   *bool
+	LogExpiredEntries            *bool
+	SavePeriod                   *string
+	PollingDelay                 *uint64
+	StatsRefreshPeriod           *string
+	Config                       *string
+	StatsDHost                   *string
+	StatsDPort                   *int
+	HealthAddr                   *string
 	RemoteSettingsUpdateInterval *uint64
 }
 
@@ -122,23 +122,23 @@ func confString(p *string, section *ini.Section, key string, def string) {
 
 func NewCTConfig() *CTConfig {
 	return &CTConfig{
-		BatchSize:          new(uint64),
-		RemoteSettingsURL:  new(string),
-		CTLogMetadata:      new(string),
-		NumThreads:         new(int),
-		LogExpiredEntries:  new(bool),
-		RunForever:         new(bool),
-		CertPath:           new(string),
-		GoogleProjectId:    new(string),
-		StatsDHost:         new(string),
-		StatsDPort:         new(int),
-		HealthAddr:         new(string),
-		RedisHost:          new(string),
-		RedisTimeout:       new(string),
-		SavePeriod:         new(string),
-		StatsRefreshPeriod: new(string),
-		PollingDelay:       new(uint64),
-		RemoteSettingsUpdateInterval:       new(uint64),
+		BatchSize:                    new(uint64),
+		RemoteSettingsURL:            new(string),
+		CTLogMetadata:                new(string),
+		NumThreads:                   new(int),
+		LogExpiredEntries:            new(bool),
+		RunForever:                   new(bool),
+		CertPath:                     new(string),
+		GoogleProjectId:              new(string),
+		StatsDHost:                   new(string),
+		StatsDPort:                   new(int),
+		HealthAddr:                   new(string),
+		RedisHost:                    new(string),
+		RedisTimeout:                 new(string),
+		SavePeriod:                   new(string),
+		StatsRefreshPeriod:           new(string),
+		PollingDelay:                 new(uint64),
+		RemoteSettingsUpdateInterval: new(uint64),
 	}
 }
 
@@ -180,7 +180,7 @@ func (c *CTConfig) Init() {
 	confBool(c.LogExpiredEntries, section, "logExpiredEntries", false)
 	confBool(c.RunForever, section, "runForever", false)
 	confUint64(c.PollingDelay, section, "pollingDelay", 600)
-	confUint64(c.RemoteSettingsUpdateInterval, section, "remoteSettingsUpdateInterval", 60)
+	confUint64(c.RemoteSettingsUpdateInterval, section, "remoteSettingsUpdateInterval", 3600)
 	confString(c.SavePeriod, section, "savePeriod", "15m")
 	confString(c.CertPath, section, "certPath", "")
 	confString(c.GoogleProjectId, section, "googleProjectId", "")

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -25,7 +25,6 @@ type CTConfig struct {
 	BatchSize          *uint64
 	NumThreads         *int
 	RunForever         *bool
-	IssuerCNFilter     *string
 	LogExpiredEntries  *bool
 	SavePeriod         *string
 	PollingDelay       *uint64
@@ -129,7 +128,6 @@ func NewCTConfig() *CTConfig {
 		NumThreads:         new(int),
 		LogExpiredEntries:  new(bool),
 		RunForever:         new(bool),
-		IssuerCNFilter:     new(string),
 		CertPath:           new(string),
 		GoogleProjectId:    new(string),
 		StatsDHost:         new(string),
@@ -184,7 +182,6 @@ func (c *CTConfig) Init() {
 	confUint64(c.PollingDelay, section, "pollingDelay", 600)
 	confUint64(c.RemoteSettingsUpdateInterval, section, "remoteSettingsUpdateInterval", 60)
 	confString(c.SavePeriod, section, "savePeriod", "15m")
-	confString(c.IssuerCNFilter, section, "issuerCNFilter", "")
 	confString(c.CertPath, section, "certPath", "")
 	confString(c.GoogleProjectId, section, "googleProjectId", "")
 	confString(c.RedisHost, section, "redisHost", "")
@@ -216,7 +213,6 @@ func (c *CTConfig) Usage() {
 	fmt.Println("remoteSettingsURL = The base url for remote settings requests")
 	fmt.Println("ctLogMetadata = A string containing a JSON array of CTLogMetadata objects, for debugging")
 	fmt.Println("googleProjectId = Google Cloud Platform Project ID, used for stackdriver logging")
-	fmt.Println("issuerCNFilter = Prefixes to match for CNs for permitted issuers, comma delimited")
 	fmt.Println("runForever = Run forever, pausing `pollingDelay` seconds between runs")
 	fmt.Println("pollingDelay= Wait time in seconds between polls. Jitter will be added.")
 	fmt.Println("logExpiredEntries = Add expired entries to the database")

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -34,6 +34,7 @@ type CTConfig struct {
 	StatsDHost         *string
 	StatsDPort         *int
 	HealthAddr         *string
+	RemoteSettingsUpdateInterval *uint64
 }
 
 func confInt(p *int, section *ini.Section, key string, def int) {
@@ -139,6 +140,7 @@ func NewCTConfig() *CTConfig {
 		SavePeriod:         new(string),
 		StatsRefreshPeriod: new(string),
 		PollingDelay:       new(uint64),
+		RemoteSettingsUpdateInterval:       new(uint64),
 	}
 }
 
@@ -180,6 +182,7 @@ func (c *CTConfig) Init() {
 	confBool(c.LogExpiredEntries, section, "logExpiredEntries", false)
 	confBool(c.RunForever, section, "runForever", false)
 	confUint64(c.PollingDelay, section, "pollingDelay", 600)
+	confUint64(c.RemoteSettingsUpdateInterval, section, "remoteSettingsUpdateInterval", 60)
 	confString(c.SavePeriod, section, "savePeriod", "15m")
 	confString(c.IssuerCNFilter, section, "issuerCNFilter", "")
 	confString(c.CertPath, section, "certPath", "")

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -16,7 +16,7 @@ import (
 )
 
 type CTConfig struct {
-	LogUrlList         *string
+	CTLogMetadata      *string
 	CertPath           *string
 	GoogleProjectId    *string
 	RedisHost          *string
@@ -122,7 +122,7 @@ func confString(p *string, section *ini.Section, key string, def string) {
 func NewCTConfig() *CTConfig {
 	return &CTConfig{
 		BatchSize:          new(uint64),
-		LogUrlList:         new(string),
+		CTLogMetadata:      new(string),
 		NumThreads:         new(int),
 		LogExpiredEntries:  new(bool),
 		RunForever:         new(bool),
@@ -172,7 +172,7 @@ func (c *CTConfig) Init() {
 
 	// Fill in values, where conf file < env vars
 	confUint64(c.BatchSize, section, "batchSize", 4096)
-	confString(c.LogUrlList, section, "logList", "")
+	confString(c.CTLogMetadata, section, "ctLogMetadata", "")
 	confInt(c.NumThreads, section, "numThreads", 1)
 	confBool(c.LogExpiredEntries, section, "logExpiredEntries", false)
 	confBool(c.RunForever, section, "runForever", false)
@@ -207,6 +207,7 @@ func (c *CTConfig) Usage() {
 	fmt.Println("redisHost = address:port of the Redis instance")
 	fmt.Println("")
 	fmt.Println("Options:")
+	fmt.Println("ctLogMetadata = A string containing a JSON array of CTLogMetadata objects, for debugging")
 	fmt.Println("googleProjectId = Google Cloud Platform Project ID, used for stackdriver logging")
 	fmt.Println("issuerCNFilter = Prefixes to match for CNs for permitted issuers, comma delimited")
 	fmt.Println("runForever = Run forever, pausing `pollingDelay` seconds between runs")
@@ -214,7 +215,6 @@ func (c *CTConfig) Usage() {
 	fmt.Println("logExpiredEntries = Add expired entries to the database")
 	fmt.Println("numThreads = Use this many threads for normal operations")
 	fmt.Println("savePeriod = Duration between state saves, e.g. 15m")
-	fmt.Println("logList = URLs of the CT Logs, comma delimited")
 	fmt.Println("statsRefreshPeriod = Period between stats being dumped to stderr, only if statsdDhost and statsdPort are not set")
 	fmt.Println("statsdHost = host for StatsD information")
 	fmt.Println("statsdPort = port for StatsD information")

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -16,6 +16,7 @@ import (
 )
 
 type CTConfig struct {
+	RemoteSettingsURL  *string
 	CTLogMetadata      *string
 	CertPath           *string
 	GoogleProjectId    *string
@@ -122,6 +123,7 @@ func confString(p *string, section *ini.Section, key string, def string) {
 func NewCTConfig() *CTConfig {
 	return &CTConfig{
 		BatchSize:          new(uint64),
+		RemoteSettingsURL:  new(string),
 		CTLogMetadata:      new(string),
 		NumThreads:         new(int),
 		LogExpiredEntries:  new(bool),
@@ -172,6 +174,7 @@ func (c *CTConfig) Init() {
 
 	// Fill in values, where conf file < env vars
 	confUint64(c.BatchSize, section, "batchSize", 4096)
+	confString(c.RemoteSettingsURL, section, "remoteSettingsURL", "")
 	confString(c.CTLogMetadata, section, "ctLogMetadata", "")
 	confInt(c.NumThreads, section, "numThreads", 1)
 	confBool(c.LogExpiredEntries, section, "logExpiredEntries", false)
@@ -207,6 +210,7 @@ func (c *CTConfig) Usage() {
 	fmt.Println("redisHost = address:port of the Redis instance")
 	fmt.Println("")
 	fmt.Println("Options:")
+	fmt.Println("remoteSettingsURL = The base url for remote settings requests")
 	fmt.Println("ctLogMetadata = A string containing a JSON array of CTLogMetadata objects, for debugging")
 	fmt.Println("googleProjectId = Google Cloud Platform Project ID, used for stackdriver logging")
 	fmt.Println("issuerCNFilter = Prefixes to match for CNs for permitted issuers, comma delimited")

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -16,24 +16,23 @@ import (
 )
 
 type CTConfig struct {
-	LogUrlList          *string
-	CertPath            *string
-	GoogleProjectId     *string
-	RedisHost           *string
-	RedisTimeout        *string
-	BatchSize           *uint64
-	NumThreads          *int
-	RunForever          *bool
-	IssuerCNFilter      *string
-	LogExpiredEntries   *bool
-	SavePeriod          *string
-	PollingDelay        *uint64
-	StatsRefreshPeriod  *string
-	OutputRefreshPeriod *string
-	Config              *string
-	StatsDHost          *string
-	StatsDPort          *int
-	HealthAddr          *string
+	LogUrlList         *string
+	CertPath           *string
+	GoogleProjectId    *string
+	RedisHost          *string
+	RedisTimeout       *string
+	BatchSize          *uint64
+	NumThreads         *int
+	RunForever         *bool
+	IssuerCNFilter     *string
+	LogExpiredEntries  *bool
+	SavePeriod         *string
+	PollingDelay       *uint64
+	StatsRefreshPeriod *string
+	Config             *string
+	StatsDHost         *string
+	StatsDPort         *int
+	HealthAddr         *string
 }
 
 func confInt(p *int, section *ini.Section, key string, def int) {
@@ -122,33 +121,30 @@ func confString(p *string, section *ini.Section, key string, def string) {
 
 func NewCTConfig() *CTConfig {
 	return &CTConfig{
-		BatchSize:           new(uint64),
-		LogUrlList:          new(string),
-		NumThreads:          new(int),
-		LogExpiredEntries:   new(bool),
-		RunForever:          new(bool),
-		IssuerCNFilter:      new(string),
-		CertPath:            new(string),
-		GoogleProjectId:     new(string),
-		StatsDHost:          new(string),
-		StatsDPort:          new(int),
-		HealthAddr:          new(string),
-		RedisHost:           new(string),
-		RedisTimeout:        new(string),
-		SavePeriod:          new(string),
-		OutputRefreshPeriod: new(string),
-		StatsRefreshPeriod:  new(string),
-		PollingDelay:        new(uint64),
+		BatchSize:          new(uint64),
+		LogUrlList:         new(string),
+		NumThreads:         new(int),
+		LogExpiredEntries:  new(bool),
+		RunForever:         new(bool),
+		IssuerCNFilter:     new(string),
+		CertPath:           new(string),
+		GoogleProjectId:    new(string),
+		StatsDHost:         new(string),
+		StatsDPort:         new(int),
+		HealthAddr:         new(string),
+		RedisHost:          new(string),
+		RedisTimeout:       new(string),
+		SavePeriod:         new(string),
+		StatsRefreshPeriod: new(string),
+		PollingDelay:       new(uint64),
 	}
 }
 
 func (c *CTConfig) Init() {
 	var confFile string
 	var flagBatchSize uint64
-	var flagOutputRefreshPeriod string
 	flag.StringVar(&confFile, "config", "", "configuration .ini file")
 	flag.Uint64Var(&flagBatchSize, "batchSize", 0, "limit on number of CT log entries to download per job")
-	flag.StringVar(&flagOutputRefreshPeriod, "outputRefreshPeriod", "125ms", "Speed for refreshing progress")
 
 	flag.Parse()
 
@@ -187,7 +183,6 @@ func (c *CTConfig) Init() {
 	confString(c.GoogleProjectId, section, "googleProjectId", "")
 	confString(c.RedisHost, section, "redisHost", "")
 	confString(c.RedisTimeout, section, "redisTimeout", "5s")
-	confString(c.OutputRefreshPeriod, section, "outputRefreshPeriod", "125ms")
 	confString(c.StatsRefreshPeriod, section, "statsRefreshPeriod", "10m")
 	confString(c.StatsDHost, section, "statsdHost", "")
 	confInt(c.StatsDPort, section, "statsdPort", 0)
@@ -196,9 +191,6 @@ func (c *CTConfig) Init() {
 	// Finally, CLI flags override
 	if flagBatchSize > 0 {
 		*c.BatchSize = flagBatchSize
-	}
-	if flagOutputRefreshPeriod != "125ms" {
-		*c.OutputRefreshPeriod = flagOutputRefreshPeriod
 	}
 }
 
@@ -223,7 +215,6 @@ func (c *CTConfig) Usage() {
 	fmt.Println("numThreads = Use this many threads for normal operations")
 	fmt.Println("savePeriod = Duration between state saves, e.g. 15m")
 	fmt.Println("logList = URLs of the CT Logs, comma delimited")
-	fmt.Println("outputRefreshPeriod = Period between output publications")
 	fmt.Println("statsRefreshPeriod = Period between stats being dumped to stderr, only if statsdDhost and statsdPort are not set")
 	fmt.Println("statsdHost = host for StatsD information")
 	fmt.Println("statsdPort = port for StatsD information")

--- a/go/downloader/downloader_test.go
+++ b/go/downloader/downloader_test.go
@@ -13,17 +13,11 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/vbauerster/mpb/v5"
 )
 
 func Test_DownloadNotFound(t *testing.T) {
 	ts := httptest.NewServer(http.NotFoundHandler())
 	defer ts.Close()
-
-	display := mpb.New(
-		mpb.WithOutput(ioutil.Discard),
-	)
 
 	tmpfile, err := ioutil.TempFile("", "Test_DownloadNotFound")
 	if err != nil {
@@ -33,7 +27,7 @@ func Test_DownloadNotFound(t *testing.T) {
 
 	url, _ := url.Parse(ts.URL)
 
-	err = DownloadFileSync(context.TODO(), display, *url, tmpfile.Name(), 3, 0)
+	err = DownloadFileSync(context.TODO(), *url, tmpfile.Name(), 3, 0)
 	if err.Error() != "Non-OK status: 404 Not Found" {
 		t.Error(err)
 	}
@@ -45,10 +39,6 @@ func Test_DownloadOK(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	display := mpb.New(
-		mpb.WithOutput(ioutil.Discard),
-	)
-
 	tmpfile, err := ioutil.TempFile("", "Test_DownloadNotFound")
 	if err != nil {
 		t.Error(err)
@@ -57,7 +47,7 @@ func Test_DownloadOK(t *testing.T) {
 
 	url, _ := url.Parse(ts.URL)
 
-	err = DownloadFileSync(context.TODO(), display, *url, tmpfile.Name(), 1, 0)
+	err = DownloadFileSync(context.TODO(), *url, tmpfile.Name(), 1, 0)
 	if err != nil {
 		t.Error(err)
 	}
@@ -99,10 +89,6 @@ func Test_DownloadFailureWithoutRetry(t *testing.T) {
 	ts := httptest.NewServer(http.Handler(&SingleFailureHandler{t: t}))
 	defer ts.Close()
 
-	display := mpb.New(
-		mpb.WithOutput(ioutil.Discard),
-	)
-
 	tmpfile, err := ioutil.TempFile("", "Test_DownloadFailureWithoutRetry")
 	if err != nil {
 		t.Error(err)
@@ -111,7 +97,7 @@ func Test_DownloadFailureWithoutRetry(t *testing.T) {
 
 	url, _ := url.Parse(ts.URL)
 
-	err = DownloadFileSync(context.TODO(), display, *url, tmpfile.Name(), 0, 0)
+	err = DownloadFileSync(context.TODO(), *url, tmpfile.Name(), 0, 0)
 	if err == nil {
 		t.Error("Should have failed")
 	}
@@ -121,10 +107,6 @@ func Test_DownloadFailureWithRetry(t *testing.T) {
 	ts := httptest.NewServer(http.Handler(&SingleFailureHandler{t: t}))
 	defer ts.Close()
 
-	display := mpb.New(
-		mpb.WithOutput(ioutil.Discard),
-	)
-
 	tmpfile, err := ioutil.TempFile("", "Test_DownloadFailureWithRetry")
 	if err != nil {
 		t.Error(err)
@@ -133,7 +115,7 @@ func Test_DownloadFailureWithRetry(t *testing.T) {
 
 	url, _ := url.Parse(ts.URL)
 
-	err = DownloadFileSync(context.TODO(), display, *url, tmpfile.Name(), 1, 0)
+	err = DownloadFileSync(context.TODO(), *url, tmpfile.Name(), 1, 0)
 	if err != nil {
 		t.Error(err)
 	}
@@ -173,13 +155,9 @@ func Test_DownloadResumeNotSupported(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	display := mpb.New(
-		mpb.WithOutput(ioutil.Discard),
-	)
-
 	url, _ := url.Parse(ts.URL)
 
-	err = DownloadFileSync(context.TODO(), display, *url, downloadedfile.Name(), 1, 0)
+	err = DownloadFileSync(context.TODO(), *url, downloadedfile.Name(), 1, 0)
 	if err != nil {
 		t.Error(err)
 	}
@@ -234,11 +212,7 @@ func Test_DownloadResume(t *testing.T) {
 	url, _ := url.Parse(ts.URL)
 	url.Path = "Test_DownloadNotFound.file"
 
-	display := mpb.New(
-		mpb.WithOutput(ioutil.Discard),
-	)
-
-	err = DownloadFileSync(context.TODO(), display, *url, downloadedfile.Name(), 1, 0)
+	err = DownloadFileSync(context.TODO(), *url, downloadedfile.Name(), 1, 0)
 	if err != nil {
 		t.Error(err)
 	}

--- a/go/downloader/verifying-downloader.go
+++ b/go/downloader/verifying-downloader.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/vbauerster/mpb/v5"
 )
 
 type DownloadVerifier interface {
@@ -21,7 +20,7 @@ type DownloadVerifier interface {
  * log the error as needed.
  */
 func DownloadAndVerifyFileSync(ctx context.Context, verifyFunc DownloadVerifier, auditor DownloadAuditor,
-	identifier DownloadIdentifier, display *mpb.Progress, crlUrl url.URL, finalPath string, maxRetries uint,
+	identifier DownloadIdentifier, crlUrl url.URL, finalPath string, maxRetries uint,
 	timeout time.Duration) (bool, error) {
 
 	dlTracer := NewDownloadTracer()
@@ -49,7 +48,7 @@ func DownloadAndVerifyFileSync(ctx context.Context, verifyFunc DownloadVerifier,
 		return false, combinedError
 	}
 
-	dlErr := DownloadFileSync(auditCtx, display, crlUrl, tmpPath, maxRetries, timeout)
+	dlErr := DownloadFileSync(auditCtx, crlUrl, tmpPath, maxRetries, timeout)
 	if dlErr != nil {
 		auditor.FailedDownload(identifier, &crlUrl, dlTracer, dlErr)
 		glog.Warningf("[%s] Failed to download from %s to tmp file %s: %s", identifier.ID(), crlUrl.String(), tmpPath, dlErr)

--- a/go/downloader/verifying-downloader_test.go
+++ b/go/downloader/verifying-downloader_test.go
@@ -10,8 +10,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-
-	"github.com/vbauerster/mpb/v5"
 )
 
 type testIdentifier struct{}
@@ -46,10 +44,6 @@ func Test_NotFoundNotLocal(t *testing.T) {
 	ts := httptest.NewServer(http.NotFoundHandler())
 	defer ts.Close()
 
-	display := mpb.New(
-		mpb.WithOutput(ioutil.Discard),
-	)
-
 	tmpfile, err := ioutil.TempFile("", "Test_NotFoundNotLocal")
 	if err != nil {
 		t.Error(err)
@@ -61,7 +55,7 @@ func Test_NotFoundNotLocal(t *testing.T) {
 	ctx := context.TODO()
 
 	dataAtPathIsValid, err := DownloadAndVerifyFileSync(ctx, &testVerifier{}, &testAuditor{},
-		&testIdentifier{}, display, *testUrl,
+		&testIdentifier{}, *testUrl,
 		tmpfile.Name(), 1, 0)
 
 	if err == nil {
@@ -84,10 +78,6 @@ func Test_NotFoundButIsLocal(t *testing.T) {
 	ts := httptest.NewServer(http.NotFoundHandler())
 	defer ts.Close()
 
-	display := mpb.New(
-		mpb.WithOutput(ioutil.Discard),
-	)
-
 	tmpfile, err := ioutil.TempFile("", "Test_NotFoundButIsLocal")
 	if err != nil {
 		t.Error(err)
@@ -100,7 +90,7 @@ func Test_NotFoundButIsLocal(t *testing.T) {
 	ctx := context.TODO()
 
 	dataAtPathIsValid, err := DownloadAndVerifyFileSync(ctx, &testVerifier{}, &testAuditor{},
-		&testIdentifier{}, display, *testUrl,
+		&testIdentifier{}, *testUrl,
 		tmpfile.Name(), 1, 0)
 
 	if err == nil {
@@ -125,10 +115,6 @@ func Test_FoundRemoteButNotLocal(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	display := mpb.New(
-		mpb.WithOutput(ioutil.Discard),
-	)
-
 	tmpfile, err := ioutil.TempFile("", "Test_FoundRemoteButNotLocal")
 	if err != nil {
 		t.Error(err)
@@ -140,7 +126,7 @@ func Test_FoundRemoteButNotLocal(t *testing.T) {
 	ctx := context.TODO()
 
 	dataAtPathIsValid, err := DownloadAndVerifyFileSync(ctx, &testVerifier{}, &testAuditor{},
-		&testIdentifier{}, display, *testUrl,
+		&testIdentifier{}, *testUrl,
 		tmpfile.Name(), 1, 0)
 
 	if err != nil {
@@ -161,10 +147,6 @@ func Test_FoundRemoteAndAlsoLocal(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	display := mpb.New(
-		mpb.WithOutput(ioutil.Discard),
-	)
-
 	tmpfile, err := ioutil.TempFile("", "Test_FoundRemoteAndAlsoLocal")
 	if err != nil {
 		t.Error(err)
@@ -177,7 +159,7 @@ func Test_FoundRemoteAndAlsoLocal(t *testing.T) {
 	ctx := context.TODO()
 
 	dataAtPathIsValid, err := DownloadAndVerifyFileSync(ctx, &testVerifier{}, &testAuditor{},
-		&testIdentifier{}, display, *testUrl,
+		&testIdentifier{}, *testUrl,
 		tmpfile.Name(), 1, 0)
 
 	if err != nil {

--- a/go/go.mod
+++ b/go/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/onsi/gomega v1.7.0 // indirect
 	github.com/smartystreets/assertions v1.0.1 // indirect
 	github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337 // indirect
-	github.com/vbauerster/mpb/v5 v5.0.3
 	golang.org/x/net v0.0.0-20191007182048-72f939374954 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/ini.v1 v1.48.0

--- a/go/go.sum
+++ b/go/go.sum
@@ -255,8 +255,6 @@ github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyC
 github.com/valyala/fasthttp v1.2.0/go.mod h1:4vX61m6KN+xDduDNwXrhIAVZaZaZiQ1luJk8LWSxF3s=
 github.com/valyala/quicktemplate v1.1.1/go.mod h1:EH+4AkTd43SvgIbQHYu59/cJyxDoOVRUAfrukLPuGJ4=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
-github.com/vbauerster/mpb/v5 v5.0.3 h1:Ldt/azOkbThTk2loi6FrBd/3fhxGFQ24MxFAS88PoNY=
-github.com/vbauerster/mpb/v5 v5.0.3/go.mod h1:h3YxU5CSr8rZP4Q3xZPVB3jJLhWPou63lHEdr9ytH4Y=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
@@ -269,6 +267,7 @@ go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20190313024323-a1f597ede03a h1:YX8ljsm6wXlHZO+aRz9Exqr0evNhKRNe5K/gi+zKh4U=
 golang.org/x/crypto v0.0.0-20190313024323-a1f597ede03a/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200311171314-f7b00557c8c4 h1:QmwruyY+bKbDDL0BaglrbZABEali68eoMFhTZpCjYVA=
 golang.org/x/crypto v0.0.0-20200311171314-f7b00557c8c4/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/go/rootprogram/issuers.go
+++ b/go/rootprogram/issuers.go
@@ -20,7 +20,6 @@ import (
 	"github.com/google/certificate-transparency-go/x509"
 	"github.com/mozilla/crlite/go/downloader"
 	"github.com/mozilla/crlite/go/storage"
-	"github.com/vbauerster/mpb/v5"
 )
 
 const (
@@ -96,10 +95,6 @@ func (i *identifier) ID() string {
 func (mi *MozIssuers) Load() error {
 	ctx := context.Background()
 
-	display := mpb.New(
-		mpb.WithOutput(ioutil.Discard),
-	)
-
 	dataUrl, err := url.Parse(mi.ReportUrl)
 	if err != nil {
 		glog.Fatalf("Couldn't parse CCADB URL of %s: %s", mi.ReportUrl, err)
@@ -107,7 +102,7 @@ func (mi *MozIssuers) Load() error {
 	}
 
 	isAcceptable, err := downloader.DownloadAndVerifyFileSync(ctx, &verifier{}, &loggingAuditor{}, &identifier{},
-		display, *dataUrl, mi.DiskPath, 3, 300*time.Second)
+		*dataUrl, mi.DiskPath, 3, 300*time.Second)
 
 	if !isAcceptable {
 		return err

--- a/go/storage/certdatabase.go
+++ b/go/storage/certdatabase.go
@@ -90,7 +90,7 @@ func (db *CertDatabase) SaveLogState(aLogObj *CertificateLog) error {
 }
 
 func (db *CertDatabase) GetLogState(aUrl *url.URL) (*CertificateLog, error) {
-	shortUrl := fmt.Sprintf("%s%s", aUrl.Host, aUrl.Path)
+	shortUrl := fmt.Sprintf("%s%s", aUrl.Host, strings.TrimRight(aUrl.Path, "/"))
 
 	log, cacheErr := db.extCache.LoadLogState(shortUrl)
 	if log != nil {

--- a/go/storage/certdatabase_test.go
+++ b/go/storage/certdatabase_test.go
@@ -173,7 +173,7 @@ func test_LogState(t *testing.T, cache RemoteCache, storageDB CertDatabase) {
 	if log.ShortURL != "log.ct/2019" {
 		t.Errorf("Unexpected ShortURL %s", log.ShortURL)
 	}
-	if log.MaxEntry != 0 || !log.LastEntryTime.IsZero() {
+	if log.MaxEntry != 0 || log.MaxTimestamp != 0 {
 		t.Errorf("Expected a blank log  %s", log.String())
 	}
 
@@ -198,7 +198,7 @@ func test_LogState(t *testing.T, cache RemoteCache, storageDB CertDatabase) {
 	if updatedLog.ShortURL != "log.ct/2019" {
 		t.Errorf("Unexpected ShortURL %s", updatedLog.ShortURL)
 	}
-	if updatedLog.MaxEntry != 9 || !updatedLog.LastEntryTime.IsZero() {
+	if updatedLog.MaxEntry != 9 || updatedLog.MaxTimestamp != 0 {
 		t.Errorf("Expected the MaxEntry to be 9 %s", updatedLog.String())
 	}
 }

--- a/go/storage/rediscache.go
+++ b/go/storage/rediscache.go
@@ -178,7 +178,7 @@ func (rc *RedisCache) TrySet(k string, v string, life time.Duration) (string, er
 }
 
 func shortUrlToLogKey(shortUrl string) string {
-	return fmt.Sprintf("log::%s", shortUrl)
+	return fmt.Sprintf("log::%s", strings.TrimRight(shortUrl, "/"))
 }
 
 func (ec *RedisCache) StoreLogState(log *CertificateLog) error {

--- a/go/storage/rediscache_test.go
+++ b/go/storage/rediscache_test.go
@@ -456,9 +456,9 @@ func TestRedisLogState(t *testing.T) {
 	defer rc.client.Del("log::short_url/location")
 
 	log := &CertificateLog{
-		ShortURL:      "short_url/location",
-		MaxEntry:      123456789,
-		LastEntryTime: time.Time{},
+		ShortURL:     "short_url/location",
+		MaxEntry:     123456789,
+		MaxTimestamp: uint64(time.Now().Unix()),
 	}
 
 	expectNilLogState(t, rc, log.ShortURL)

--- a/go/storage/storagebackend_tests.go
+++ b/go/storage/storagebackend_tests.go
@@ -117,7 +117,7 @@ func BackendTestLogState(t *testing.T, db StorageBackend) {
 	if log.ShortURL != testLogURL {
 		t.Errorf("Unexpected URL %s", log.ShortURL)
 	}
-	if log.MaxEntry != 0 || !log.LastEntryTime.IsZero() {
+	if log.MaxEntry != 0 || log.MaxTimestamp != 0 {
 		t.Errorf("Expected a blank log  %s", log.String())
 	}
 
@@ -135,13 +135,13 @@ func BackendTestLogState(t *testing.T, db StorageBackend) {
 		if updatedLog.ShortURL != testLogURL {
 			t.Errorf("Unexpected URL %s", updatedLog.ShortURL)
 		}
-		if updatedLog.MaxEntry != 9 || !updatedLog.LastEntryTime.IsZero() {
+		if updatedLog.MaxEntry != 9 || updatedLog.MaxTimestamp != 0 {
 			t.Errorf("Expected the MaxEntry to be 9 and the time to be unset %s", updatedLog.String())
 		}
 	}
 
 	log.MaxEntry = 0xDEADBEEF
-	log.LastEntryTime = time.Unix(1567016306, 0)
+	log.MaxTimestamp = 1567016306
 	err = db.StoreLogState(context.TODO(), log)
 	if err != nil {
 		t.Errorf("Shouldn't have errored saving %v", err)
@@ -158,11 +158,11 @@ func BackendTestLogState(t *testing.T, db StorageBackend) {
 		if updatedLog.MaxEntry != 0xDEADBEEF {
 			t.Errorf("Expected the MaxEntry to be 0xDEADBEEF %s", updatedLog.String())
 		}
-		if updatedLog.LastEntryTime.IsZero() {
+		if updatedLog.MaxTimestamp == 0 {
 			t.Errorf("Expected the MaxEntry to be non-zero %s", updatedLog.String())
 		}
-		if updatedLog.LastEntryTime.Unix() != 1567016306 {
-			t.Errorf("Expected the LastEntryTime to be 1567016306. %s", updatedLog.String())
+		if updatedLog.MaxTimestamp != 1567016306 {
+			t.Errorf("Expected the MaxTimestamp to be 1567016306. %s", updatedLog.String())
 		}
 	}
 }

--- a/go/storage/types.go
+++ b/go/storage/types.go
@@ -23,14 +23,15 @@ const (
 
 type CertificateLog struct {
 	ShortURL       string    `db:"url"`            // URL to the log
-	MinEntry       uint64    `db:"minEntry"`       // The earliest entryID logged
-	MaxEntry       uint64    `db:"maxEntry"`       // The most recent entryID logged
+	MinEntry       uint64    `db:"minEntry"`       // The smallest index we've downloaded
+	MaxEntry       uint64    `db:"maxEntry"`       // The largest index we've downloaded
 	LastEntryTime  time.Time `db:"lastEntryTime"`  // Date of the most recently logged entry
 	LastUpdateTime time.Time `db:"lastUpdateTime"` // Date when we completed the last update
 }
 
 func (o *CertificateLog) String() string {
-	return fmt.Sprintf("[%s] MaxEntry=%d, LastEntryTime=%s LastUpdateTime=%s", o.ShortURL, o.MaxEntry, o.LastEntryTime, o.LastUpdateTime)
+	return fmt.Sprintf("[%s] MinEntry=%d MaxEntry=%d, LastEntryTime=%s LastUpdateTime=%s",
+		o.ShortURL, o.MinEntry, o.MaxEntry, o.LastEntryTime, o.LastUpdateTime)
 }
 
 func CertificateLogIDFromShortURL(shortURL string) string {

--- a/go/storage/types.go
+++ b/go/storage/types.go
@@ -22,6 +22,8 @@ const (
 )
 
 type CertificateLog struct {
+	LogID          string    `db:"logID"`          // The log's RFC 6962 LogID
+	MMD            uint64    `db:"mmd"`            // The log's maximum merge delay in seconds
 	ShortURL       string    `db:"url"`            // URL to the log
 	MinEntry       uint64    `db:"minEntry"`       // The smallest index we've downloaded
 	MaxEntry       uint64    `db:"maxEntry"`       // The largest index we've downloaded

--- a/go/storage/types.go
+++ b/go/storage/types.go
@@ -25,13 +25,14 @@ type CertificateLog struct {
 	ShortURL       string    `db:"url"`            // URL to the log
 	MinEntry       uint64    `db:"minEntry"`       // The smallest index we've downloaded
 	MaxEntry       uint64    `db:"maxEntry"`       // The largest index we've downloaded
-	LastEntryTime  time.Time `db:"lastEntryTime"`  // Date of the most recently logged entry
+	MinTimestamp   uint64    `db:"minTimestamp"`   // Unix timestamp of the earliest entry we've downloaded
+	MaxTimestamp   uint64    `db:"maxTimestamp"`   // Unix timestamp of the most recent entry we've downloaded
 	LastUpdateTime time.Time `db:"lastUpdateTime"` // Date when we completed the last update
 }
 
 func (o *CertificateLog) String() string {
-	return fmt.Sprintf("[%s] MinEntry=%d MaxEntry=%d, LastEntryTime=%s LastUpdateTime=%s",
-		o.ShortURL, o.MinEntry, o.MaxEntry, o.LastEntryTime, o.LastUpdateTime)
+	return fmt.Sprintf("[%s] MinEntry=%d, MaxEntry=%d, MaxTimestamp=%d, LastUpdateTime=%s",
+		o.ShortURL, o.MinEntry, o.MaxEntry, o.MaxTimestamp, o.LastUpdateTime)
 }
 
 func CertificateLogIDFromShortURL(shortURL string) string {

--- a/go/storage/types.go
+++ b/go/storage/types.go
@@ -23,7 +23,8 @@ const (
 
 type CertificateLog struct {
 	ShortURL       string    `db:"url"`            // URL to the log
-	MaxEntry       int64     `db:"maxEntry"`       // The most recent entryID logged
+	MinEntry       uint64    `db:"minEntry"`       // The earliest entryID logged
+	MaxEntry       uint64    `db:"maxEntry"`       // The most recent entryID logged
 	LastEntryTime  time.Time `db:"lastEntryTime"`  // Date of the most recently logged entry
 	LastUpdateTime time.Time `db:"lastUpdateTime"` // Date when we completed the last update
 }

--- a/go/storage/types_test.go
+++ b/go/storage/types_test.go
@@ -173,11 +173,11 @@ func TestLog(t *testing.T) {
 	log := CertificateLog{
 		ShortURL:       "log.example.com/2525",
 		MaxEntry:       math.MaxInt64,
-		LastEntryTime:  time.Date(2525, time.May, 20, 19, 21, 54, 39, time.UTC),
+		MaxTimestamp:   uint64(time.Date(2525, time.May, 20, 19, 21, 54, 39, time.UTC).Unix()),
 		LastUpdateTime: time.Date(3000, time.December, 31, 23, 55, 59, 0, time.UTC),
 	}
 
-	expectedString := "[log.example.com/2525] MaxEntry=9223372036854775807, LastEntryTime=2525-05-20 19:21:54.000000039 +0000 UTC LastUpdateTime=3000-12-31 23:55:59 +0000 UTC"
+	expectedString := "[log.example.com/2525] MinEntry=0, MaxEntry=9223372036854775807, MaxTimestamp=17526223314, LastUpdateTime=3000-12-31 23:55:59 +0000 UTC"
 	if log.String() != expectedString {
 		t.Errorf("Expecting %s but got %s", expectedString, log.String())
 	}
@@ -189,9 +189,9 @@ func TestLog(t *testing.T) {
 
 	// From previous version
 	log = CertificateLog{
-		ShortURL:      "yeti2021.ct.digicert.com/log/",
-		MaxEntry:      1517184,
-		LastEntryTime: time.Date(2019, time.August, 30, 05, 30, 16, 82, time.UTC),
+		ShortURL:     "yeti2021.ct.digicert.com/log/",
+		MaxEntry:     1517184,
+		MaxTimestamp: uint64(time.Date(2019, time.August, 30, 05, 30, 16, 82, time.UTC).Unix()),
 	}
 
 	expectedID = "eWV0aTIwMjEuY3QuZGlnaWNlcnQuY29tL2xvZy8="

--- a/go/types.go
+++ b/go/types.go
@@ -9,12 +9,12 @@ import (
 )
 
 type CTLogMetadata struct {
-	CRLiteEnrolled bool    `json:"crlite_enrolled"`
-	Description    string  `json:"description"`
-	Key            string  `json:"key"`
-	LogID          string  `json:"logID"`
-	MMD            int     `json:"mmd"`
-	URL            string  `json:"url"`
+	CRLiteEnrolled bool   `json:"crlite_enrolled"`
+	Description    string `json:"description"`
+	Key            string `json:"key"`
+	LogID          string `json:"logID"`
+	MMD            int    `json:"mmd"`
+	URL            string `json:"url"`
 }
 
 type IssuerCrlMap map[string]map[string]bool

--- a/go/types.go
+++ b/go/types.go
@@ -8,6 +8,15 @@ import (
 	"github.com/mozilla/crlite/go/storage"
 )
 
+type CTLogMetadata struct {
+	CRLiteEnrolled bool    `json:"crlite_enrolled"`
+	Description    string  `json:"description"`
+	Key            string  `json:"key"`
+	LogID          string  `json:"logID"`
+	MMD            int     `json:"mmd"`
+	URL            string  `json:"url"`
+}
+
 type IssuerCrlMap map[string]map[string]bool
 
 func (self IssuerCrlMap) Merge(other IssuerCrlMap) {


### PR DESCRIPTION
Another grab bag of changes. The most important is 3470cba507c570cb73d3865c8e12b8562077d6ea, which uses go context cancellation to try and cleanly shut down worker threads. Mostly a stylistic change, we were previously listening for signals in each worker thread and this just puts the signal handling logic in one place.