### PR TITLE
aggregate-known: save ct log metadata

### DIFF
--- a/containers/scripts/crlite-generate.sh
+++ b/containers/scripts/crlite-generate.sh
@@ -26,6 +26,7 @@ ${crlite_bin:-~/go/bin}/aggregate-crls -crlpath ${crlite_persistent:-/ct}/crls \
 
 ${crlite_bin:-~/go/bin}/aggregate-known -knownpath ${ID}/known \
               -enrolledpath ${ID}/enrolled.json \
+              -ctlogspath ${ID}/ct-logs.json \
               -stderrthreshold=INFO -alsologtostderr \
               -log_dir ${WORKDIR}/log
 

--- a/go/storage/certdatabase.go
+++ b/go/storage/certdatabase.go
@@ -42,6 +42,10 @@ func (db *CertDatabase) GetIssuerMetadata(aIssuer Issuer) *IssuerMetadata {
 	return im
 }
 
+func (db *CertDatabase) GetCTLogsFromCache() ([]CertificateLog, error) {
+	return db.extCache.LoadAllLogStates()
+}
+
 func (db *CertDatabase) GetIssuerAndDatesFromCache() ([]IssuerDate, error) {
 	issuerMap := make(map[string]IssuerDate)
 	allChan := make(chan string)

--- a/go/storage/localdiskbackend.go
+++ b/go/storage/localdiskbackend.go
@@ -258,3 +258,7 @@ func (db *LocalDiskBackend) LoadLogState(_ context.Context, logURL string) (*Cer
 
 	return &log, nil
 }
+
+func (db *LocalDiskBackend) LoadAllLogStates(_ context.Context) ([]CertificateLog, error) {
+	return nil, fmt.Errorf("Unimplemented")
+}

--- a/go/storage/mockbackend.go
+++ b/go/storage/mockbackend.go
@@ -146,3 +146,7 @@ func (db *MockBackend) StreamSerialsForExpirationDateAndIssuer(ctx context.Conte
 	}
 	return nil
 }
+
+func (ec *MockBackend) LoadAllLogStates(_ context.Context) ([]CertificateLog, error) {
+	return nil, fmt.Errorf("Unimplemented")
+}

--- a/go/storage/mockcache.go
+++ b/go/storage/mockcache.go
@@ -218,3 +218,7 @@ func (ec *MockRemoteCache) LoadLogState(shortUrl string) (*CertificateLog, error
 	}
 	return &log, nil
 }
+
+func (ec *MockRemoteCache) LoadAllLogStates() ([]CertificateLog, error) {
+	return nil, fmt.Errorf("Unimplemented")
+}

--- a/go/storage/types.go
+++ b/go/storage/types.go
@@ -59,6 +59,7 @@ type StorageBackend interface {
 	LoadCertificatePEM(ctx context.Context, serial Serial, expDate ExpDate,
 		issuer Issuer) ([]byte, error)
 	LoadLogState(ctx context.Context, logURL string) (*CertificateLog, error)
+	LoadAllLogStates(ctx context.Context) ([]CertificateLog, error)
 
 	AllocateExpDateAndIssuer(ctx context.Context, expDate ExpDate, issuer Issuer) error
 
@@ -90,6 +91,7 @@ type RemoteCache interface {
 	KeysToChan(pattern string, c chan<- string) error
 	StoreLogState(aLogObj *CertificateLog) error
 	LoadLogState(aLogUrl string) (*CertificateLog, error)
+	LoadAllLogStates() ([]CertificateLog, error)
 }
 
 type Issuer struct {


### PR DESCRIPTION
The `ct-fetch` job now saves metadata in redis about which log entries it has seen. With this PR, `aggregate-known` will read the CT log metadata from redis and save it in a "ct-logs.json" file. It's important that `aggregate-known` performs this task, and not `moz_kinto_publisher`, because ct-fetch runs continuously and we want the metadata at the time when `aggregate-known` was called.
 
Resolves #194 