### PR TITLE
Decouple publish and signoff logic

### DIFF
--- a/containers/scripts/crlite-signoff-tool.py
+++ b/containers/scripts/crlite-signoff-tool.py
@@ -1,93 +1,155 @@
 #!/usr/bin/env python3
 
-from decouple import config
-from google.api_core import exceptions
-from pathlib import Path
-
 import argparse
 import hashlib
-import requests
 import subprocess
 import sys
 import tempfile
+from pathlib import Path
+
+import requests
 import glog as log
 
+from decouple import config
+
+from kinto_http import Client
+from kinto_http.patch_type import BasicPatch
+from kinto_http.exceptions import KintoException
+
+KINTO_RW_SERVER_URL = config(
+    "KINTO_RW_SERVER_URL", default="https://settings-writer.stage.mozaws.net/v1/"
+)
 KINTO_RO_SERVER_URL = config(
     "KINTO_RO_SERVER_URL", default="https://settings-cdn.stage.mozaws.net/v1/"
 )
-KINTO_BUCKET = config("KINTO_BUCKET", default="security-state-preview")
+KINTO_AUTH_USER = config("KINTO_AUTH_USER", default="")
+KINTO_AUTH_PASSWORD = config("KINTO_AUTH_PASSWORD", default="")
+KINTO_BUCKET = config("KINTO_BUCKET", default="security-state-staging")
 KINTO_CRLITE_COLLECTION = config("KINTO_CRLITE_COLLECTION", default="cert-revocations")
+KINTO_INTERMEDIATES_COLLECTION = config(
+    "KINTO_INTERMEDIATES_COLLECTION", default="intermediates"
+)
+KINTO_NOOP = config("KINTO_NOOP", default=False, cast=bool)
+
 CRLITE_FRESHNESS_HOURS = config("CRLITE_FRESHNESS_HOURS", default="2")
 
-parser = argparse.ArgumentParser()
-parser.add_argument(
-    "--moz-crlite-query", help="Path to the moz-crlite-query tool", required=True
-)
-parser.add_argument(
-    "--host-file-urls",
-    help="URLs of host files to download and check, comma or space (or both) delimited",
-    nargs="+",
-    default=[],
-    metavar="url",
-)
+
+class SignoffClient(Client):
+    def sign_collection(self, *, collection=None):
+        try:
+            resp = self.get_collection(id=collection)
+        except KintoException as e:
+            log.error(f"Couldn't determine {collection} review status: {e}")
+            raise e
+
+        original = resp.get("data")
+        if original is None:
+            raise KintoException("Malformed response from Kinto")
+
+        status = original.get("status")
+        if status is None:
+            raise KintoException("Malformed response from Kinto")
+
+        if status != "to-review":
+            log.info("Collection is not marked for review. Skipping.")
+            return
+
+        try:
+            resp = self.patch_collection(
+                original=original, changes=BasicPatch({"status": "to-sign"})
+            )
+        except KintoException as e:
+            log.error(f"Couldn't sign {collection}")
+            raise e
 
 
-def main():
-    args = parser.parse_args()
-
+def download_host_file(filename, output_dir, host_url):
     headers = {"X-Automated-Tool": "https://github.com/mozilla/crlite"}
-
-    try:
-        with tempfile.TemporaryDirectory() as tempDir:
-            sub_args = [
-                sys.executable,
-                args.moz_crlite_query,
-                "--force-update",
-                "--db",
-                tempDir,
-                "--crlite-url",
-                KINTO_RO_SERVER_URL
-                + str(
-                    Path("buckets")
-                    / KINTO_BUCKET
-                    / "collections"
-                    / KINTO_CRLITE_COLLECTION
-                    / "records"
-                ),
-                "--check-not-revoked",
-                "--check-freshness",
-                CRLITE_FRESHNESS_HOURS,
-                "--structured",
-            ]
-
-            for host_url in args.host_file_urls:
-                host_url = host_url.strip(", ")
-                filename = hashlib.sha256(host_url.encode("utf-8")).hexdigest()
-                hosts_file_path = Path(tempDir) / filename
-                r = requests.get(host_url, headers=headers)
-                r.raise_for_status()
-                with hosts_file_path.open("wb") as fd:
-                    for chunk in r.iter_content(chunk_size=1024):
-                        fd.write(chunk)
-                sub_args.extend(["--hosts-file", str(hosts_file_path)])
-                log.info(
-                    f"Downloaded {host_url} to {hosts_file_path} "
-                    + f"(sz={hosts_file_path.stat().st_size})"
-                )
-
-            log.info(f"Running {sub_args}")
-            subprocess.run(sub_args, check=True)
-
-    except requests.exceptions.HTTPError as e:
-        log.fatal(f"Could not download hosts file to check: {e}")
-        sys.exit(1)
-    except exceptions.NotFound as e:
-        log.fatal(f"Could not download existing filter: {e}")
-        sys.exit(1)
-    except subprocess.CalledProcessError as e:
-        log.fatal(f"Error in moz_crlite_query: {e}")
-        sys.exit(1)
+    hosts_file_path = Path(output_dir) / filename
+    r = requests.get(host_url, headers=headers)
+    r.raise_for_status()
+    with hosts_file_path.open("wb") as fd:
+        fd.write(r.content)
+    log.info(
+        f"Downloaded {host_url} to {hosts_file_path} "
+        + f"(sz={hosts_file_path.stat().st_size})"
+    )
 
 
 if __name__ == "__main__":
-    main()
+    OK = 0
+    ERROR = 1
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--noop", default=KINTO_NOOP, action="store_true", help="Don't update Kinto"
+    )
+    parser.add_argument(
+        "--moz-crlite-query", help="Path to the moz-crlite-query tool", required=True
+    )
+    parser.add_argument(
+        "--host-file-urls",
+        help="URLs of host files to download and check, comma or space (or both) delimited",
+        nargs="+",
+        default=[],
+        metavar="url",
+    )
+    args = parser.parse_args()
+
+    sub_args = [
+        sys.executable,
+        args.moz_crlite_query,
+        "--force-update",
+        "--crlite-url",
+        KINTO_RO_SERVER_URL
+        + str(
+            Path("buckets")
+            / KINTO_BUCKET
+            / "collections"
+            / KINTO_CRLITE_COLLECTION
+            / "records"
+        ),
+        "--check-not-revoked",
+        "--check-freshness",
+        CRLITE_FRESHNESS_HOURS,
+        "--structured",
+    ]
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        sub_args.extend(["--db", temp_dir])
+        for url in args.host_file_urls:
+            filename = hashlib.sha256(url.encode("utf-8")).hexdigest()
+            try:
+                download_host_file(filename, temp_dir, url)
+            except requests.exceptions.HTTPError as e:
+                log.error(f"Could not download hosts file to check: {e}")
+                sys.exit(ERROR)
+            sub_args.extend(["--hosts-file", str(Path(temp_dir) / filename)])
+
+        log.info(f"Running {sub_args}")
+        try:
+            subprocess.run(sub_args, check=True)
+        except subprocess.CalledProcessError as e:
+            log.error(f"Error in moz_crlite_query: {e}")
+            sys.exit(ERROR)
+
+    if args.noop:
+        log.info("Would sign off, but noop requested")
+        sys.exit(OK)
+
+    auth = requests.auth.HTTPBasicAuth(KINTO_AUTH_USER, KINTO_AUTH_PASSWORD)
+    rw_client = SignoffClient(
+        server_url=KINTO_RW_SERVER_URL,
+        auth=auth,
+        bucket=KINTO_BUCKET,
+        retry=5,
+    )
+
+    try:
+        rw_client.sign_collection(collection=KINTO_CRLITE_COLLECTION)
+        rw_client.sign_collection(collection=KINTO_INTERMEDIATES_COLLECTION)
+    except KintoException as e:
+        log.error(f"Kinto exception: {e}")
+        sys.exit(ERROR)
+
+    sys.exit(OK)

--- a/containers/scripts/crlite-signoff.sh
+++ b/containers/scripts/crlite-signoff.sh
@@ -4,13 +4,6 @@ workflow=${crlite_workflow:-~/go/src/github.com/mozilla/crlite/workflow}
 
 source ${workflow}/0-set_credentials.inc
 
-if [ "x${DoNotUpload}x" != "xx" ] || [ "x${KINTO_NOOP}x" != "xx" ] ; then
-  ARGS="--noop"
-  echo "Setting argument ${ARGS}"
-fi
-
 python3 /app/scripts/crlite-signoff-tool.py \
   --moz-crlite-query /usr/local/bin/moz_crlite_query \
   --host-file-urls ${crlite_verify_host_file_urls}
-
-exit 0

--- a/moz_kinto_publisher/main.py
+++ b/moz_kinto_publisher/main.py
@@ -161,7 +161,7 @@ class PublisherClient(Client):
             raise KintoException("Malformed response from Kinto")
 
         if status != "work-in-progress":
-            log.info("Collection is not marked for review. Skipping.")
+            log.info(f"Collection {collection} is unchanged. Does not need review.")
             return
 
         try:

--- a/moz_kinto_publisher/settings.py
+++ b/moz_kinto_publisher/settings.py
@@ -8,7 +8,6 @@ KINTO_RO_SERVER_URL = config(
 )
 KINTO_AUTH_USER = config("KINTO_AUTH_USER", default="")
 KINTO_AUTH_PASSWORD = config("KINTO_AUTH_PASSWORD", default="")
-KINTO_AUTH_TOKEN = config("KINTO_AUTH_TOKEN", default="")
 KINTO_BUCKET = config("KINTO_BUCKET", default="security-state-staging")
 KINTO_CRLITE_COLLECTION = config("KINTO_CRLITE_COLLECTION", default="cert-revocations")
 KINTO_INTERMEDIATES_COLLECTION = config(


### PR DESCRIPTION
This PR is only for the last two commits, 498dcc7337a8c0eaa7c8ffdeb6ef331ca9e66e6f and 32dfcf03094c916d19bc26712c3adc989fae6c6a. The changeset is stacked on top of #197.

I removed some signoff logic from moz_kinto_publisher as part of #175. This completes the task of moving that logic over to the CRLite signoff tool. The signoff workflow is described here: https://github.com/Kinto/kinto-signer#workflows.

Depends #197 
Resolves #198