### PR TITLE
moz_kinto_publisher: avoid a confusing log message in dev environment

### DIFF
--- a/moz_kinto_publisher/main.py
+++ b/moz_kinto_publisher/main.py
@@ -1029,7 +1029,10 @@ def publish_crlite(*, args, rw_client):
                 noop=args.noop,
             )
 
-    rw_client.request_review_of_collection(collection=settings.KINTO_CRLITE_COLLECTION)
+    if not args.noop:
+        rw_client.request_review_of_collection(
+            collection=settings.KINTO_CRLITE_COLLECTION
+        )
 
 
 def publish_ctlogs(*, args, rw_client):
@@ -1166,7 +1169,10 @@ def publish_ctlogs(*, args, rw_client):
         except KintoException as ke:
             log.error(f"Update failed, {ke}")
 
-    rw_client.request_review_of_collection(collection=settings.KINTO_CTLOGS_COLLECTION)
+    if not args.noop:
+        rw_client.request_review_of_collection(
+            collection=settings.KINTO_CTLOGS_COLLECTION
+        )
 
 
 def main():


### PR DESCRIPTION
Calling `request_review_of_collection` in the dev environment results in an HTTP error because we don't have access to the right server. We can avoid this by skipping the call if `noop` is enabled

Part of the general log message cleanup in #207 