### PR TITLE
Remove duplicate entries from `intermediates` and check enrollment in signoff

### DIFF
--- a/containers/scripts/crlite-signoff-tool.py
+++ b/containers/scripts/crlite-signoff-tool.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 
 import argparse
+import datetime
 import hashlib
 import subprocess
 import sys
+import json
 import tempfile
 from pathlib import Path
 
@@ -15,6 +17,8 @@ from decouple import config
 from kinto_http import Client
 from kinto_http.patch_type import BasicPatch
 from kinto_http.exceptions import KintoException
+
+import workflow
 
 KINTO_RW_SERVER_URL = config(
     "KINTO_RW_SERVER_URL", default="https://settings-writer.stage.mozaws.net/v1/"
@@ -62,6 +66,65 @@ class SignoffClient(Client):
             log.error(f"Couldn't sign {collection}")
             raise e
 
+    def get_current_full_filter_id(self):
+        records = self.get_records(collection=KINTO_CRLITE_COLLECTION)
+        full_filters = [x for x in records if not x["incremental"]]
+        if len(full_filters) == 0:
+            raise KintoException("No full filter")
+        if len(full_filters) > 1:
+            raise KintoException("Multiple full filters")
+        full_filter = full_filters[0]
+        if not (
+            "attachment" in full_filter and "filename" in full_filter["attachment"]
+        ):
+            raise KintoException("Malformed record")
+        run_id = full_filter["attachment"]["filename"].rsplit("-", 1)[0]
+        return run_id
+
+    def verify_enrollment(self, *, enrollment_path):
+        with enrollment_path.open("r") as f:
+            aggregator_records = json.load(f)
+        rs_records = self.get_records(collection=KINTO_INTERMEDIATES_COLLECTION)
+
+        # An intermediate is identified by its Subject DN and SPKI hash
+        k = lambda x: (x["subjectDN"], x["pubKeyHash"])
+
+        # We may have multiple certificates for an intermediate. These should all
+        # have the same `crlite_enrolled` value.
+        rs_icas = {}
+        for r in rs_records:
+            if k(r) not in rs_icas:
+                rs_icas[k(r)] = r
+            elif r["crlite_enrolled"] != rs_icas[k(r)]["crlite_enrolled"]:
+                raise KintoException(
+                    f"Inconsistent enrollment for {r['subject']}--{r['pubKeyHash']}"
+                )
+
+        # The CRLite aggregator and Remote Settings should agree on enrollment
+        for r in aggregator_records:
+            if k(r) not in rs_icas:
+                # This usually indicates that we skipped enrollment because of
+                # a defect in the intermediate's certificate. The CRLite
+                # aggregator and moz_kinto_publisher don't use the same library
+                # for parsing x509 certs; the library that moz_kinto_publisher
+                # uses is more strict.
+                log.warning(
+                    f"Missing remote settings record for {r['subject']}--{r['pubKeyHash']}"
+                )
+            elif r["enrollment"] != rs_icas[k(r)]["enrollment"]:
+                raise KintoException(
+                    f"Inconsistent enrollment for {r['subject']}--{r['pubKeyHash']}"
+                )
+
+
+def download_full_filter_enrollment(*, filter_bucket, run_id, save_path):
+    workflow.download_and_retry_from_google_cloud(
+        filter_bucket,
+        f"{run_id}/enrolled.json",
+        save_path,
+        timeout=datetime.timedelta(minutes=5),
+    )
+
 
 def download_host_file(filename, output_dir, host_url):
     headers = {"X-Automated-Tool": "https://github.com/mozilla/crlite"}
@@ -94,7 +157,36 @@ if __name__ == "__main__":
         default=[],
         metavar="url",
     )
+    parser.add_argument("--filter-bucket", default="crlite_filters")
     args = parser.parse_args()
+
+    if args.noop:
+        rs_client = SignoffClient(
+            server_url=KINTO_RO_SERVER_URL,
+            auth=None,
+            bucket=KINTO_BUCKET,
+            retry=5,
+        )
+    else:
+        auth = requests.auth.HTTPBasicAuth(KINTO_AUTH_USER, KINTO_AUTH_PASSWORD)
+        rs_client = SignoffClient(
+            server_url=KINTO_RW_SERVER_URL,
+            auth=auth,
+            bucket=KINTO_BUCKET,
+            retry=5,
+        )
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        try:
+            run_id = rs_client.get_current_full_filter_id()
+            save_path = Path(temp_dir) / "enrolled.json"
+            download_full_filter_enrollment(
+                filter_bucket=args.filter_bucket, run_id=run_id, save_path=save_path
+            )
+            rs_client.verify_enrollment(enrollment_path=save_path)
+        except Exception as e:
+            log.error(f"Error verifying enrollment: {e}")
+            sys.exit(ERROR)
 
     sub_args = [
         sys.executable,
@@ -137,17 +229,9 @@ if __name__ == "__main__":
         log.info("Would sign off, but noop requested")
         sys.exit(OK)
 
-    auth = requests.auth.HTTPBasicAuth(KINTO_AUTH_USER, KINTO_AUTH_PASSWORD)
-    rw_client = SignoffClient(
-        server_url=KINTO_RW_SERVER_URL,
-        auth=auth,
-        bucket=KINTO_BUCKET,
-        retry=5,
-    )
-
     try:
-        rw_client.sign_collection(collection=KINTO_CRLITE_COLLECTION)
-        rw_client.sign_collection(collection=KINTO_INTERMEDIATES_COLLECTION)
+        rs_client.sign_collection(collection=KINTO_CRLITE_COLLECTION)
+        rs_client.sign_collection(collection=KINTO_INTERMEDIATES_COLLECTION)
     except KintoException as e:
         log.error(f"Kinto exception: {e}")
         sys.exit(ERROR)

--- a/containers/scripts/crlite-signoff.sh
+++ b/containers/scripts/crlite-signoff.sh
@@ -5,5 +5,6 @@ workflow=${crlite_workflow:-~/go/src/github.com/mozilla/crlite/workflow}
 source ${workflow}/0-set_credentials.inc
 
 python3 /app/scripts/crlite-signoff-tool.py \
+  --filter-bucket ${crlite_filter_bucket:-crlite_filters_staging} \
   --moz-crlite-query /usr/local/bin/moz_crlite_query \
   --host-file-urls ${crlite_verify_host_file_urls}

--- a/moz_kinto_publisher/main.py
+++ b/moz_kinto_publisher/main.py
@@ -488,6 +488,7 @@ def load_remote_intermediates(*, kinto_client):
     ):
         try:
             intObj = Intermediate(**record)
+            intObj.download_pem()  # intObj.pemAttachment was set by constructor
             remote_intermediates[intObj.unique_id()] = intObj
         except IntermediateRecordError as ire:
             log.warning("Skipping broken intermediate record at Kinto: {}".format(ire))

--- a/moz_kinto_publisher/main.py
+++ b/moz_kinto_publisher/main.py
@@ -489,14 +489,14 @@ def load_remote_intermediates(*, kinto_client):
         try:
             intObj = Intermediate(**record)
             intObj.download_pem()  # intObj.pemAttachment was set by constructor
-            remote_intermediates[intObj.unique_id()] = intObj
+            if intObj.unique_id() in remote_intermediates:
+                log.warning("Will remove duplicate intermediate: {intObj}")
+                remote_error_records.append(record)
+            else:
+                remote_intermediates[intObj.unique_id()] = intObj
         except IntermediateRecordError as ire:
             log.warning("Skipping broken intermediate record at Kinto: {}".format(ire))
             remote_error_records.append(record)
-        except KeyError as ke:
-            log.error("Critical error importing Kinto dataset: {}".format(ke))
-            log.error("Record: {}".format(record))
-            raise ke
     return remote_intermediates, remote_error_records
 
 


### PR DESCRIPTION
Resolves #230 - Add enrollment checks to signoff tool
Resolves #231 - Remove duplicate entries in intermediates collection

I've also made it so that we download pem attachments inside of `load_remote_intermediates` rather than while checking expiry dates. There are a few intermediates in the remote settings collection with certificates that python cryptography rejects as malformed. The changes to `load_remote_intermediates` will cause these entries to be deleted.