### PR TITLE
Relax sign-off checks for unenrolled intermediates

### DIFF
--- a/containers/scripts/crlite-signoff-tool.py
+++ b/containers/scripts/crlite-signoff-tool.py
@@ -127,7 +127,7 @@ class SignoffClient(Client):
                 log.warning(
                     f"Missing remote settings record for {r['subject']}--{r['pubKeyHash']}"
                 )
-            elif r["enrolled"] != rs_icas[r_id]["crlite_enrolled"]:
+            elif r["enrolled"] == False and rs_icas[r_id]["crlite_enrolled"] == True:
                 raise KintoException(
                     f"Inconsistent enrollment for {r['subject']}--{r['pubKeyHash']}"
                 )

--- a/moz_kinto_publisher/main.py
+++ b/moz_kinto_publisher/main.py
@@ -610,14 +610,15 @@ def publish_intermediates(*, args, rw_client, new_filter_run_id=None):
     for unique_id in to_update:
         local_int = local_intermediates[unique_id]
         remote_int = remote_intermediates[unique_id]
-        if not allow_crlite_enrollment:
-            log.info(f"Skipping enrollment of: {local_int}")
-            local_int.crlite_enrolled = False
+        if not allow_crlite_enrollment and local_int.crlite_enrolled:
+            if not remote_int.crlite_enrolled:
+                log.info(f"Skipping enrollment of: {local_int}")
+                local_int.crlite_enrolled = False
         # Enrollment might be the only change, and might be
         # disallowed. So we might not have an update at all.
         if local_int.equals(remote_record=remote_int):
             continue
-        log.info(f"Updating record: {local_int} to {remote_int}")
+        log.info(f"Updating record: {remote_int} to {local_int}")
         try:
             local_int.update_kinto(
                 rw_client=rw_client,


### PR DESCRIPTION
Resolves #239 

Also fixes a confusing log message in moz_kinto_publisher.