### PR TITLE
Store the current filter's enrolled issuer list in cert-revocations

### DIFF
--- a/go/rootprogram/issuers.go
+++ b/go/rootprogram/issuers.go
@@ -39,6 +39,7 @@ type IssuerData struct {
 }
 
 type EnrolledIssuer struct {
+	UniqueID   string `json:"uniqueID"`
 	PubKeyHash string `json:"pubKeyHash"`
 	Whitelist  bool   `json:"whitelist"`
 	SubjectDN  string `json:"subjectDN"`
@@ -163,7 +164,9 @@ func (mi *MozIssuers) SaveIssuersList(filePath string) error {
 	for _, val := range mi.issuerMap {
 		for _, cert := range val.certs {
 			pubKeyHash := sha256.Sum256(cert.cert.RawSubjectPublicKeyInfo)
+			uniqueID := sha256.Sum256(append(cert.cert.RawSubject, cert.cert.RawSubjectPublicKeyInfo...))
 			issuers = append(issuers, EnrolledIssuer{
+				UniqueID:   base64.URLEncoding.EncodeToString(uniqueID[:]),
 				PubKeyHash: base64.URLEncoding.EncodeToString(pubKeyHash[:]),
 				Whitelist:  false,
 				SubjectDN:  base64.URLEncoding.EncodeToString([]byte(cert.subjectDN)),

--- a/moz_kinto_publisher/main.py
+++ b/moz_kinto_publisher/main.py
@@ -870,6 +870,8 @@ def crlite_verify_record_consistency(*, existing_records):
             raise ConsistencyException(f"Malformed record {r}.")
         if not r["incremental"] and not "coverage" in r:
             raise ConsistencyException(f"Malformed record {r}.")
+        if not r["incremental"] and not "enrolledIssuers" in r:
+            raise ConsistencyException(f"Malformed record {r}.")
 
     # There must be exactly 1 full filter in the existing records.
     full_filters = [r for r in existing_records if not r["incremental"]]


### PR DESCRIPTION
Resolves #241 

~Note: The `crlite_enrollment_id.py` script is not used here. I needed it while making tests for the client-side code, and I think it makes more sense to keep it here with CRLite than mozilla-central.~ [edit: moved script to mozilla-central]