### PR TITLE
Fix issues with enrolledIssuers

### DIFF
--- a/moz_kinto_publisher/main.py
+++ b/moz_kinto_publisher/main.py
@@ -803,7 +803,7 @@ def publish_crlite_main_filter(
     for issuer in intermediates:
         if issuer["enrolled"]:
             uid = base64.urlsafe_b64decode(issuer["uniqueID"])
-            enrolledIssuers.append(base64.b64encode(uid))
+            enrolledIssuers.add(base64.b64encode(uid).decode("utf-8"))
     enrolledIssuers = list(enrolledIssuers)
 
     attributes = {

--- a/moz_kinto_publisher/main.py
+++ b/moz_kinto_publisher/main.py
@@ -799,11 +799,12 @@ def publish_crlite_main_filter(
             }
         ]
 
-    enrolledIssuers = []
+    enrolledIssuers = set()
     for issuer in intermediates:
         if issuer["enrolled"]:
             uid = base64.urlsafe_b64decode(issuer["uniqueID"])
             enrolledIssuers.append(base64.b64encode(uid))
+    enrolledIssuers = list(enrolledIssuers)
 
     attributes = {
         "details": {"name": identifier},


### PR DESCRIPTION
Fix up an encoding issue, and only publish one copy of each issuer ID (`enrolled.json` has duplicates from cross-signed certs).