### PR TITLE
signoff: Configure filter size limit through max_filter_size env var

### DIFF
--- a/containers/scripts/crlite-signoff.sh
+++ b/containers/scripts/crlite-signoff.sh
@@ -5,6 +5,7 @@ BIN="${crlite_bin:-/app}"
 SCRIPTS="${BIN}/scripts"
 OUTPUT="${crlite_processing:-/processing}/crlite_db"
 RUST_QUERY_CRLITE="${BIN}/rust-query-crlite"
+MAX_FILTER_SIZE=${max_filter_size:-10485760}
 
 source "${WORKFLOW}/0-set_credentials.inc"
 
@@ -22,13 +23,22 @@ fi
 # sign off on intermediates
 python3 "${SCRIPTS}/crlite-signoff-tool.py" intermediates
 
-# Sign off on cert-revocations if the verification domains test passes and the
-# filter is less than 10 MB.
-if "${RUST_QUERY_CRLITE}" -vvv --db "${OUTPUT}" --update "${INSTANCE}" signoff "${crlite_verify_host_file_urls}"
+# sign off on cert-revocations if the verification domains test passes and the
+# filter is less than MAX_FILTER_SIZE.
+FILTER_SIZE=$(stat --format=%s "${OUTPUT}/crlite.filter")
+echo "Filter is ${FILTER_SIZE} bytes."
+
+if (( FILTER_SIZE > MAX_FILTER_SIZE ))
 then
-  if (( $(stat --format=%s "${OUTPUT}/crlite.filter") < 10*1024*1024 ))
-  then
-    python3 "${SCRIPTS}/crlite-signoff-tool.py" cert-revocations
-  fi
+  echo "Cannot automatically sign off on a filter larger than max_filter_size=${MAX_FILTER_SIZE} bytes."
+  exit 1;
 fi
 
+if ! "${RUST_QUERY_CRLITE}" -vvv --db "${OUTPUT}" --update "${INSTANCE}" signoff "${crlite_verify_host_file_urls}"
+then
+  echo "Verification domains test failed"
+  exit 1;
+fi
+
+echo "Running signoff tool"
+python3 "${SCRIPTS}/crlite-signoff-tool.py" cert-revocations


### PR DESCRIPTION
This adds a bit more debugging info during signoff and makes the filter size cutoff configurable through an environment variable.