### PR TITLE
Use rust:latest in Dockerfile

### DIFF
--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -8,9 +8,7 @@ RUN go build -o bin/aggregate-crls /build/cmd/aggregate-crls
 RUN go build -o bin/aggregate-known /build/cmd/aggregate-known
 RUN go build -o bin/ct-fetch /build/cmd/ct-fetch
 
-
-# rust-cascade with the builder feature needs rust >= 1.61.
-FROM rust:1.61-bullseye as rust-builder
+FROM rust:latest as rust-builder
 RUN mkdir /build
 
 ADD rust-create-cascade /build/rust-create-cascade/


### PR DESCRIPTION
Builds are currently failing with
> error: package `time v0.3.20` cannot be built because it requires rustc 1.63.0 or newer, while the currently active rustc version is 1.61.0

I don't see any harm in building with the `rust:latest` image.