### PR TITLE
Fetch previous revset.bin from latest folder

### DIFF
--- a/workflow/2-generate_mlbf
+++ b/workflow/2-generate_mlbf
@@ -43,20 +43,16 @@ def main():
 
     if not args.nodiff and "GOOGLE_APPLICATION_CREDENTIALS" in os.environ:
         try:
-            all_runs = workflow.get_run_identifiers(args.filter_bucket)
-            if all_runs:
-                latest = all_runs.pop()
-                dest = Path(tempfile.mkdtemp()) / Path(latest)
-                dest.mkdir()
-                prev_revset = dest / Path("prev_revset.bin")
+            dest = Path(tempfile.mkdtemp())
+            prev_revset = dest / Path("prev_revset.bin")
 
-                workflow.download_from_google_cloud(
-                    args.filter_bucket,
-                    f"{latest}/mlbf/revset.bin",
-                    prev_revset,
-                )
+            workflow.download_from_google_cloud(
+                args.filter_bucket,
+                "latest/revset.bin",
+                prev_revset,
+            )
 
-                cmdline = cmdline + ["--prev-revset", prev_revset]
+            cmdline = cmdline + ["--prev-revset", prev_revset]
         except exceptions.NotFound as e:
             log.error(f"Could not download existing filter: {e}")
         except Exception as e:


### PR DESCRIPTION
The change in v1.0.20 to upload source data before uploading the new filter breaks the mechanism that `workflow/2-generate-mlbf` used to find the previous run's `revset.bin` file. There's no reason to look up the latest run's identifier, we can just grab `revset.bin` from the `/latest` folder.