### PR TITLE
rust-create-cascade: avoid duplicate insertion of revoked serials

### DIFF
--- a/rust-create-cascade/src/main.rs
+++ b/rust-create-cascade/src/main.rs
@@ -159,6 +159,8 @@ fn include<T>(
             builder
                 .include(key)
                 .expect("Capacity error. Did the file contents change?");
+            // Ensure that we do not attempt to include this issuer+serial again.
+            revoked_serial_set.remove(serial);
         }
     }
 }


### PR DESCRIPTION
On Jan 31 [a certificate](https://crt.sh/?id=11926218289) was issued by GLOBALTRUST 2020 SERVER OV 1 with serial number [32daef359edc5cdaa0b9fa](https://crt.sh/?serial=32daef359edc5cdaa0b9fa). The same serial number was used in [a precertificate](https://crt.sh/?id=11916527958) with a different validity period. This serial number collision caused the CRLite ct-fetch process to store the the same serial number in two different issuer+notAfter bins in its database, which caused the serial number to appear twice in the "known" list for the issuer.

Rust-create-cascade assumes that it cannot store the full "known" list in memory, so it does not check for duplicates. When rust-create-cascade is building a filter, it iterates over the known list and checks whether the serial is in the "revoked" set. If it is, rust-create-cascade inserts the serial into the filter.

The duplicate serial number caused rust-create-cascade to insert the same issuer+serial key into the filter twice. This triggered a safety check built into rust-cascade, which caused rust-create-cascade to exit without producing a filter.

This patch removes serials from the "revoked" set as they are used, so that duplicate entries in the "known" list will not cause this problem.