### PR TITLE
rust-create-cascade: statsd telemetry

### DIFF
--- a/containers/scripts/crlite-generate.sh
+++ b/containers/scripts/crlite-generate.sh
@@ -52,7 +52,8 @@ if [ "x${DoNotUpload}x" == "xx" ] ; then
 fi
 
 ${workflow}/2-generate_mlbf ${ID} \
-              --filter-bucket ${crlite_filter_bucket:-crlite_filters_staging}
+              --filter-bucket ${crlite_filter_bucket:-crlite_filters_staging} \
+              --statsd-host ${statsdHost}
 
 if [ "x${DoNotUpload}x" == "xx" ] ; then
   echo "uploading mlbf"

--- a/rust-create-cascade/Cargo.toml
+++ b/rust-create-cascade/Cargo.toml
@@ -11,4 +11,5 @@ log = "0.4"
 rand="0.7"
 rayon = "1.5"
 rust_cascade = { version = "1.5.0" , features = ["builder"] }
+statsd = "0.16.0"
 stderrlog = "0.5"

--- a/workflow/2-generate_mlbf
+++ b/workflow/2-generate_mlbf
@@ -17,7 +17,9 @@ parser.add_argument("--nodiff", help="Avoid building a diff")
 parser.add_argument(
     "--filter-bucket", help="Google Cloud Storage filter bucket name", required=True
 )
-
+parser.add_argument(
+    "--statsd-host", help="StatsD host", required=False
+)
 
 def main():
     args = parser.parse_args()
@@ -40,6 +42,10 @@ def main():
         os.path.join(runIdPath, "mlbf"),
         "--clobber",
     ]
+
+    if args.statsd_host:
+        cmdline += ["--statsd-host", args.statsd_host]
+
 
     if not args.nodiff and "GOOGLE_APPLICATION_CREDENTIALS" in os.environ:
         try:


### PR DESCRIPTION
Let's push some telemetry to statsd so we can set up alerts through grafana.

The new probes are:
- `crlite.generate.revoked`: number of known revoked certificates
- `crlite.generate.not_revoked`: number of known not-revoked certificates
- `crlite.generate.filter_size`: filter size in bytes
- `crlite.generate.stash_size`: latest stash size in bytes
- `crlite.generate.revset_size`: uncompressed revocation set size in bytes
- `crlite.generate.time`: seconds spent in filter generation