### PR TITLE
Plumb revocation reason codes through to the filter generation process

### DIFF
--- a/go/storage/localdiskbackend.go
+++ b/go/storage/localdiskbackend.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"bufio"
 	"context"
+	"encoding/hex"
 	"os"
 	"path/filepath"
 
@@ -36,6 +37,8 @@ func makeDirectoryIfNotExist(id string) error {
 	return nil
 }
 
+// Write a line delimited list of serial numbers to a text file. The serial
+// numbers are lowercase hex encoded.
 func (db *LocalDiskBackend) StoreKnownCertificateList(ctx context.Context, issuer types.Issuer,
 	serials []types.Serial) error {
 	path := filepath.Join(db.rootPath, issuer.ID())
@@ -58,6 +61,47 @@ func (db *LocalDiskBackend) StoreKnownCertificateList(ctx context.Context, issue
 			return ctx.Err()
 		default:
 			_, err := writer.WriteString(s.HexString())
+			if err != nil {
+				return err
+			}
+			err = writer.WriteByte('\n')
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// Write a line delimited list of serial numbers and reason codes to a text
+// file. Each line contains hex encoded binary data. The first (encoded) byte
+// in each line is the reason code. The remaining bytes are the serial number.
+func (db *LocalDiskBackend) StoreRevokedCertificateList(ctx context.Context, issuer types.Issuer,
+	serials []types.SerialAndReason) error {
+	path := filepath.Join(db.rootPath, issuer.ID())
+	if err := makeDirectoryIfNotExist(path); err != nil {
+		return err
+	}
+
+	fd, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, db.perms)
+	if err != nil {
+		return err
+	}
+	defer fd.Close()
+
+	writer := bufio.NewWriter(fd)
+	defer writer.Flush()
+
+	for _, s := range serials {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			_, err = writer.WriteString(hex.EncodeToString([]byte{s.Reason}))
+			if err != nil {
+				return err
+			}
+			_, err := writer.WriteString(s.Serial.HexString())
 			if err != nil {
 				return err
 			}

--- a/go/storage/mockbackend.go
+++ b/go/storage/mockbackend.go
@@ -27,3 +27,14 @@ func (db *MockBackend) StoreKnownCertificateList(_ context.Context, issuer types
 	db.store[issuer.ID()] = encoded
 	return nil
 }
+
+func (db *MockBackend) StoreRevokedCertificateList(_ context.Context, issuer types.Issuer,
+	serials []types.SerialAndReason) error {
+	encoded, err := json.Marshal(serials)
+	if err != nil {
+		return err
+	}
+
+	db.store[issuer.ID()] = encoded
+	return nil
+}

--- a/go/storage/noopbackend.go
+++ b/go/storage/noopbackend.go
@@ -22,3 +22,8 @@ func (db *NoopBackend) StoreKnownCertificateList(_ context.Context, _ types.Issu
 	_ []types.Serial) error {
 	return nil
 }
+
+func (db *NoopBackend) StoreRevokedCertificateList(_ context.Context, _ types.Issuer,
+	_ []types.SerialAndReason) error {
+	return nil
+}

--- a/go/storage/types.go
+++ b/go/storage/types.go
@@ -10,6 +10,8 @@ import (
 type StorageBackend interface {
 	StoreKnownCertificateList(ctx context.Context, issuer types.Issuer,
 		serials []types.Serial) error
+	StoreRevokedCertificateList(ctx context.Context, issuer types.Issuer,
+		serials []types.SerialAndReason) error
 }
 
 type RemoteCache interface {

--- a/go/types.go
+++ b/go/types.go
@@ -217,6 +217,11 @@ func (c RevokedCertificateWithRawSerial) Reason() (asn1.Enumerated, error) {
 			seen = true
 		}
 	}
+
+	if reasonCode < 0 || reasonCode > 255 {
+		return reasonCode, fmt.Errorf("Invalid reason code")
+	}
+
 	return reasonCode, nil
 }
 
@@ -224,10 +229,6 @@ func (c RevokedCertificateWithRawSerial) SerialAndReason() (SerialAndReason, err
 	reason, err := c.Reason()
 	if err != nil {
 		return SerialAndReason{}, err
-	}
-
-	if reason < 0 || reason > 255 {
-		return SerialAndReason{}, fmt.Errorf("Invalid reason code")
 	}
 
 	return SerialAndReason{


### PR DESCRIPTION
This PR changes the output of aggregate-crls such that each serial number is prefixed by a one byte revocation reason code. The data is still encoded as line-delimited ascii hex.

This code is currently running on the dev instance. I've added dashboard entries for the new statsd telemetry.