### PR TITLE
Produce filters that encode a limited set of reason codes

### DIFF
--- a/containers/scripts/crlite-generate.sh
+++ b/containers/scripts/crlite-generate.sh
@@ -53,7 +53,18 @@ fi
 
 ${workflow}/2-generate_mlbf ${ID} \
               --filter-bucket ${crlite_filter_bucket:-crlite_filters_staging} \
-              --statsd-host ${statsdHost}
+              --statsd-host ${statsdHost} \
+              --reason-set all
+
+${workflow}/2-generate_mlbf ${ID} \
+              --filter-bucket ${crlite_filter_bucket:-crlite_filters_staging} \
+              --statsd-host ${statsdHost} \
+              --reason-set specified
+
+${workflow}/2-generate_mlbf ${ID} \
+              --filter-bucket ${crlite_filter_bucket:-crlite_filters_staging} \
+              --statsd-host ${statsdHost} \
+              --reason-set key-compromise
 
 if [ "x${DoNotUpload}x" == "xx" ] ; then
   echo "uploading mlbf"

--- a/rust-create-cascade/Cargo.toml
+++ b/rust-create-cascade/Cargo.toml
@@ -13,3 +13,4 @@ rayon = "1.5"
 rust_cascade = { version = "1.5.0" , features = ["builder"] }
 statsd = "0.16.0"
 stderrlog = "0.5"
+tempfile = "3.10.1"

--- a/rust-create-cascade/src/main.rs
+++ b/rust-create-cascade/src/main.rs
@@ -180,17 +180,15 @@ impl RevokedSerialAndReasonIterator {
 impl Iterator for RevokedSerialAndReasonIterator {
     type Item = (Serial, Reason);
     fn next(&mut self) -> Option<Self::Item> {
-        let next = self.lines.next().transpose().expect("IO error");
-        if let Some(mut line) = next {
+        while let Some(mut line) = self.lines.next().transpose().expect("IO error") {
             let reason = decode_reason(&line[..2]);
             if self.skip_reason(&reason) {
-                return self.next();
+                continue;
             }
             let serial = line.split_off(2);
-            Some((serial, reason))
-        } else {
-            None
+            return Some((serial, reason));
         }
+        None
     }
 }
 

--- a/workflow/2-generate_mlbf
+++ b/workflow/2-generate_mlbf
@@ -17,9 +17,13 @@ parser.add_argument("--nodiff", help="Avoid building a diff")
 parser.add_argument(
     "--filter-bucket", help="Google Cloud Storage filter bucket name", required=True
 )
+parser.add_argument("--statsd-host", help="StatsD host", required=False)
 parser.add_argument(
-    "--statsd-host", help="StatsD host", required=False
+    "--reason-set",
+    help="Reason set [values: all, specified, key-compromise]",
+    required=False,
 )
+
 
 def main():
     args = parser.parse_args()
@@ -38,14 +42,21 @@ def main():
         os.path.join(runIdPath, "known"),
         "--revoked",
         os.path.join(runIdPath, "revoked"),
-        "--outdir",
-        os.path.join(runIdPath, "mlbf"),
         "--clobber",
     ]
 
     if args.statsd_host:
         cmdline += ["--statsd-host", args.statsd_host]
 
+    if not args.reason_set or args.reason_set == "all":
+        cmdline += ["--outdir", os.path.join(runIdPath, "mlbf")]
+    else:
+        cmdline += [
+            "--outdir",
+            os.path.join(runIdPath, f"mlbf-{args.reason_set}"),
+            "--reason-set",
+            args.reason_set,
+        ]
 
     if not args.nodiff and "GOOGLE_APPLICATION_CREDENTIALS" in os.environ:
         try:

--- a/workflow/3-upload_mlbf_to_storage
+++ b/workflow/3-upload_mlbf_to_storage
@@ -77,6 +77,16 @@ def main():
         # Add a copy to /latest
         uploadFiles(files, localFolder, Path("latest"), bucket, args=args)
 
+    for path, dirs, files in os.walk(runIdPath / "mlbf-specified"):
+        localFolder = Path(path)
+        remoteFolder = localFolder.relative_to(runIdPath.parent)
+        uploadFiles(files, localFolder, remoteFolder, bucket, args=args)
+
+    for path, dirs, files in os.walk(runIdPath / "mlbf-key-compromise"):
+        localFolder = Path(path)
+        remoteFolder = localFolder.relative_to(runIdPath.parent)
+        uploadFiles(files, localFolder, remoteFolder, bucket, args=args)
+
     sentinel = bucket.blob(str(Path(runIdPath.name) / "completed"))
     log.info(f"Saving 'completed' marker to {sentinel.name}")
     if not args.noop:


### PR DESCRIPTION
With this PR you can pass `--reason-set all` to rust-create-cascade to produce a filter that encodes all revocations, or
`--reason-set specified` to produce a filter that encodes revocations with specified reason codes, or `--reason-set key-compromise` to produce a filter that encodes key compromise revocations.

I've updated crlite-generate.sh so that each kind of filter is produced and stored in cloud storage. I've not updated moz_kinto_publisher, so only the `--reason set all` filter will actually be published through remote settings.