### PR TITLE
Fix a few bugs discovered in staging testing of filter channels

### DIFF
--- a/moz_kinto_publisher/main.py
+++ b/moz_kinto_publisher/main.py
@@ -972,7 +972,7 @@ def crlite_determine_publish(*, existing_records, run_db, channel):
 
     # A run ID is a "YYYYMMDD" date and an index, e.g. "20210101-3".
     # The record["attachment"]["filename"] field of an existing record is
-    # in the format "<run id>-filter" or "<run id>-filter.stash".
+    # in the format "<run id>-channel.filter" or "<run id>-channel.filter.stash".
     record_run_ids = [
         record["attachment"]["filename"].rsplit("-", 1)[0]
         for record in existing_records
@@ -1135,7 +1135,7 @@ def publish_crlite(*, args, rw_client, channel):
         assert filter_path.is_file(), "Missing local copy of filter"
         publish_crlite_main_filter(
             filter_path=filter_path,
-            filename=f"{final_run_id}-{channel}-filter",
+            filename=f"{final_run_id}-{channel}.filter",
             rw_client=rw_client,
             timestamp=published_run_db.get_run_timestamp(final_run_id),
             ctlogs=ctlogs,
@@ -1154,7 +1154,7 @@ def publish_crlite(*, args, rw_client, channel):
 
             previous_id = publish_crlite_stash(
                 stash_path=stash_path,
-                filename=f"{run_id}-{channel}-filter.stash",
+                filename=f"{run_id}-{channel}.filter.stash",
                 rw_client=rw_client,
                 previous_id=previous_id,
                 timestamp=published_run_db.get_run_timestamp(run_id),

--- a/moz_kinto_publisher/main.py
+++ b/moz_kinto_publisher/main.py
@@ -29,6 +29,15 @@ CHANNEL_ALL = "all"
 CHANNEL_SPECIFIED = "specified"
 CHANNEL_PRIORITY = "priority"
 
+def get_mlbf_dir(channel):
+    if channel == CHANNEL_ALL:
+        return "mlbf"
+    elif channel == CHANNEL_SPECIFIED:
+        return "mlbf-specified"
+    elif channel == CHANNEL_PRIORITY:
+        return "mlbf-priority"
+    log.warning(f"Unrecognized channel ({channel}).")
+    return None
 
 class IntermediateRecordError(KintoException):
     pass
@@ -52,14 +61,8 @@ class PublishedRunDB:
         return len(self.run_identifiers)
 
     def is_run_valid(self, run_id, channel):
-        if channel == CHANNEL_ALL:
-            mlbf_dir = "mlbf"
-        elif channel == CHANNEL_SPECIFIED:
-            mlbf_dir = "mlbf-specified"
-        elif channel == CHANNEL_PRIORITY:
-            mlbf_dir = "mlbf-priority"
-        else:
-            log.warning(f"Unrecognized channel ({channel}).")
+        mlbf_dir = get_mlbf_dir(channel)
+        if mlbf_dir == None:
             return False
 
         is_valid = (
@@ -1058,14 +1061,8 @@ def publish_crlite(*, args, rw_client, channel):
 
     filter_path = final_run_id_path / Path("filter")
 
-    if channel == CHANNEL_ALL:
-        mlbf_dir = "mlbf"
-    elif channel == CHANNEL_SPECIFIED:
-        mlbf_dir = "mlbf-specified"
-    elif channel == CHANNEL_PRIORITY:
-        mlbf_dir = "mlbf-priority"
-    else:
-        log.warning(f"Unrecognized channel ({channel}).")
+    mlbf_dir = get_mlbf_dir(channel)
+    if mlbf_dir == None:
         return rv
 
     workflow.download_and_retry_from_google_cloud(

--- a/moz_kinto_publisher/main.py
+++ b/moz_kinto_publisher/main.py
@@ -29,6 +29,7 @@ CHANNEL_ALL = "all"
 CHANNEL_SPECIFIED = "specified"
 CHANNEL_PRIORITY = "priority"
 
+
 def get_mlbf_dir(channel):
     if channel == CHANNEL_ALL:
         return "mlbf"
@@ -38,6 +39,7 @@ def get_mlbf_dir(channel):
         return "mlbf-priority"
     log.warning(f"Unrecognized channel ({channel}).")
     return None
+
 
 class IntermediateRecordError(KintoException):
     pass

--- a/moz_kinto_publisher/test_publisher.py
+++ b/moz_kinto_publisher/test_publisher.py
@@ -51,7 +51,7 @@ class MockRunDB(main.PublishedRunDB):
     def get_run_timestamp(self, run_id):
         return timestamp_from_run_id(run_id)
 
-    def is_run_valid(self, run_id):
+    def is_run_valid(self, run_id, channel):
         return run_id in self.run_identifiers
 
     def is_run_ready(self, run_id):
@@ -198,6 +198,7 @@ class TestPublishDecisions(unittest.TestCase):
                     "20491231-3",
                     "20500101-0",
                 ],
+                channel="all"
             )
 
     def test_run_id_consistency_out_of_order(self):
@@ -206,6 +207,7 @@ class TestPublishDecisions(unittest.TestCase):
             main.crlite_verify_run_id_consistency(
                 run_db=db,
                 identifiers_to_check=["20491230-3", "20491231-1", "20491231-0"],
+                channel="all"
             )
 
     def test_run_id_consistency_okay(self):
@@ -221,11 +223,12 @@ class TestPublishDecisions(unittest.TestCase):
         main.crlite_verify_run_id_consistency(
             run_db=db,
             identifiers_to_check=identifiers,
+            channel="all"
         )
 
     def test_run_id_consistency_empty(self):
         db = MockRunDB([])
-        main.crlite_verify_run_id_consistency(run_db=db, identifiers_to_check=[])
+        main.crlite_verify_run_id_consistency(run_db=db, identifiers_to_check=[], channel="all")
 
     def test_initial_conditions(self):
         existing_records = []

--- a/moz_kinto_publisher/test_publisher.py
+++ b/moz_kinto_publisher/test_publisher.py
@@ -198,7 +198,7 @@ class TestPublishDecisions(unittest.TestCase):
                     "20491231-3",
                     "20500101-0",
                 ],
-                channel="all"
+                channel="all",
             )
 
     def test_run_id_consistency_out_of_order(self):
@@ -207,7 +207,7 @@ class TestPublishDecisions(unittest.TestCase):
             main.crlite_verify_run_id_consistency(
                 run_db=db,
                 identifiers_to_check=["20491230-3", "20491231-1", "20491231-0"],
-                channel="all"
+                channel="all",
             )
 
     def test_run_id_consistency_okay(self):
@@ -221,14 +221,14 @@ class TestPublishDecisions(unittest.TestCase):
         ]
         db = MockRunDB(identifiers)
         main.crlite_verify_run_id_consistency(
-            run_db=db,
-            identifiers_to_check=identifiers,
-            channel="all"
+            run_db=db, identifiers_to_check=identifiers, channel="all"
         )
 
     def test_run_id_consistency_empty(self):
         db = MockRunDB([])
-        main.crlite_verify_run_id_consistency(run_db=db, identifiers_to_check=[], channel="all")
+        main.crlite_verify_run_id_consistency(
+            run_db=db, identifiers_to_check=[], channel="all"
+        )
 
     def test_initial_conditions(self):
         existing_records = []


### PR DESCRIPTION
Fixes three issues found in staging testing:
1) the publisher would fail before the first generate task finished because is_run_valid didn't check for existence of mlbf-specified and mlbf-priority files,
2) the publisher assumed that attachment filenames contain exactly two hyphens when checking run id consistency,
3) the signoff job would fail because rust-query-crlite didn't filter records by channel.