### PR TITLE
moz_kinto_publisher: avoid overriding PublishedRunDB functions in MockRunDB tests

### DIFF
--- a/moz_kinto_publisher/main.py
+++ b/moz_kinto_publisher/main.py
@@ -69,7 +69,7 @@ class PublishedRunDB:
 
         is_valid = (
             workflow.google_cloud_file_exists(
-                self.filter_bucket, f"{run_id}/{mblf_dir}/filter"
+                self.filter_bucket, f"{run_id}/{mlbf_dir}/filter"
             )
             and workflow.google_cloud_file_exists(
                 self.filter_bucket, f"{run_id}/{mlbf_dir}/filter.stash"

--- a/moz_kinto_publisher/test_publisher.py
+++ b/moz_kinto_publisher/test_publisher.py
@@ -2,6 +2,9 @@ import main
 import settings
 import unittest
 import hashlib
+import os
+import pytest
+import workflow
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -12,7 +15,7 @@ def timestamp_from_run_id(run_id):
     return datetime.strptime(time_string, "%Y%m%d-%H").replace(tzinfo=timezone.utc)
 
 
-def make_record(run_id, *, parent, channel):
+def make_record(run_id, *, parent, channel=main.CHANNEL_ALL):
     timestamp = timestamp_from_run_id(run_id)
     record_type = "diff" if parent else "full"
     record_time = timestamp.isoformat(timespec="seconds")
@@ -45,17 +48,21 @@ def make_record(run_id, *, parent, channel):
 
 
 class MockRunDB(main.PublishedRunDB):
-    def __init__(self, runs):
-        self.run_identifiers = runs
-
-    def get_run_timestamp(self, run_id):
-        return timestamp_from_run_id(run_id)
-
-    def is_run_valid(self, run_id, channel):
-        return run_id in self.run_identifiers
-
-    def is_run_ready(self, run_id):
-        return True
+    def __init__(self, runs, completed_runs, channel=main.CHANNEL_ALL):
+        for run in runs:
+            os.mkdir(Path(run))
+        mlbf_dir = main.get_mlbf_dir(channel)
+        for run in completed_runs:
+            os.mkdir(Path(run) / mlbf_dir)
+            (Path(run) / mlbf_dir / "filter").touch()
+            (Path(run) / mlbf_dir / "filter.stash").touch()
+            (Path(run) / "ct-logs.json").touch()
+            (Path(run) / "completed").touch()
+            (Path(run) / "timestamp").write_text(
+                timestamp_from_run_id(run).isoformat(timespec="seconds"),
+                encoding="utf-8",
+            )
+        main.PublishedRunDB.__init__(self, workflow.kTestBucket + ":" + str(Path()))
 
 
 class TestTimestampMethods(unittest.TestCase):
@@ -87,108 +94,113 @@ class TestLoadIntermediates(unittest.TestCase):
 
 
 class TestPublishDecisions(unittest.TestCase):
+    # Create a new temporary directory and cd into it for each test.
+    @pytest.fixture(autouse=True)
+    def initdir(self, tmpdir, monkeypatch):
+        monkeypatch.chdir(tmpdir)
+
     def test_consistency_okay(self):
         existing_records = [
-            make_record("20491230-3", parent=None, channel="all"),
-            make_record("20491231-0", parent="20491230-3", channel="all"),
-            make_record("20491231-1", parent="20491231-0", channel="all"),
-            make_record("20491231-2", parent="20491231-1", channel="all"),
-            make_record("20491231-3", parent="20491231-2", channel="all"),
-            make_record("20500101-0", parent="20491231-3", channel="all"),
+            make_record("20491230-3", parent=None),
+            make_record("20491231-0", parent="20491230-3"),
+            make_record("20491231-1", parent="20491231-0"),
+            make_record("20491231-2", parent="20491231-1"),
+            make_record("20491231-3", parent="20491231-2"),
+            make_record("20500101-0", parent="20491231-3"),
         ]
         main.crlite_verify_record_consistency(
-            existing_records=existing_records, channel="all"
+            existing_records=existing_records, channel=main.CHANNEL_ALL
         )
 
     def test_consistency_okay(self):
         existing_records = [
-            make_record("20491230-3", parent=None, channel="all"),
-            make_record("20491231-0", parent="20491230-3", channel="all"),
-            make_record("20491231-1", parent="20491231-0", channel="all"),
-            make_record("20491231-2", parent="20491231-1", channel="all"),
-            make_record("20491231-3", parent="20491231-2", channel="all"),
-            make_record("20500101-0", parent="20491231-3", channel="all"),
+            make_record("20491230-3", parent=None),
+            make_record("20491231-0", parent="20491230-3"),
+            make_record("20491231-1", parent="20491231-0"),
+            make_record("20491231-2", parent="20491231-1"),
+            make_record("20491231-3", parent="20491231-2"),
+            make_record("20500101-0", parent="20491231-3"),
         ]
         main.crlite_verify_record_consistency(
-            existing_records=existing_records, channel="all"
+            existing_records=existing_records, channel=main.CHANNEL_ALL
         )
 
     def test_consistency_multiple_channels(self):
         existing_records = [
-            make_record("20491230-3", parent=None, channel="all"),
-            make_record("20491231-0", parent="20491230-3", channel="all"),
-            make_record("20491231-1", parent="20491231-0", channel="all"),
-            make_record("20491231-2", parent=None, channel="specified"),
-            make_record("20491231-3", parent="20491231-2", channel="specified"),
-            make_record("20500101-0", parent="20491231-3", channel="specified"),
+            make_record("20491230-3", parent=None),
+            make_record("20491231-0", parent="20491230-3"),
+            make_record("20491231-1", parent="20491231-0"),
+            make_record("20491231-2", parent=None, channel=main.CHANNEL_SPECIFIED),
+            make_record("20491231-3", parent="20491231-2", channel=main.CHANNEL_SPECIFIED),
+            make_record("20500101-0", parent="20491231-3", channel=main.CHANNEL_SPECIFIED),
         ]
         main.crlite_verify_record_consistency(
-            existing_records=existing_records, channel="specified"
+            existing_records=existing_records, channel=main.CHANNEL_SPECIFIED
         )
 
     def test_consistency_multiple_filters(self):
         existing_records = [
-            make_record("20491230-3", parent=None, channel="all"),
-            make_record("20491231-0", parent="20491230-3", channel="all"),
-            make_record("20491231-1", parent="20491231-0", channel="all"),
-            make_record("20491231-2", parent=None, channel="all"),
-            make_record("20491231-3", parent="20491231-2", channel="all"),
-            make_record("20500101-0", parent="20491231-3", channel="all"),
+            make_record("20491230-3", parent=None),
+            make_record("20491231-0", parent="20491230-3"),
+            make_record("20491231-1", parent="20491231-0"),
+            make_record("20491231-2", parent=None),
+            make_record("20491231-3", parent="20491231-2"),
+            make_record("20500101-0", parent="20491231-3"),
         ]
         with self.assertRaises(main.ConsistencyException):
             main.crlite_verify_record_consistency(
-                existing_records=existing_records, channel="all"
+                existing_records=existing_records, channel=main.CHANNEL_ALL
             )
 
     def test_consistency_not_sequential(self):
         existing_records = [
-            make_record("20491230-3", parent=None, channel="all"),
-            make_record("20491231-0", parent="20491230-3", channel="all"),
-            make_record("20491231-1", parent="20491231-0", channel="all"),
-            make_record("20491231-3", parent="20491231-1", channel="all"),
-            make_record("20500101-0", parent="20491231-3", channel="all"),
+            make_record("20491230-3", parent=None),
+            make_record("20491231-0", parent="20491230-3"),
+            make_record("20491231-1", parent="20491231-0"),
+            make_record("20491231-3", parent="20491231-1"),
+            make_record("20500101-0", parent="20491231-3"),
         ]
         with self.assertRaises(main.ConsistencyException):
             main.crlite_verify_record_consistency(
-                existing_records=existing_records, channel="all"
+                existing_records=existing_records, channel=main.CHANNEL_ALL
             )
 
     def test_consistency_out_of_order(self):
         existing_records = [
-            make_record("20491230-3", parent=None, channel="all"),
-            make_record("20491231-1", parent="20491231-0", channel="all"),
-            make_record("20491231-0", parent="20491230-3", channel="all"),
+            make_record("20491230-3", parent=None),
+            make_record("20491231-1", parent="20491231-0"),
+            make_record("20491231-0", parent="20491230-3"),
         ]
         with self.assertRaises(main.ConsistencyException):
             main.crlite_verify_record_consistency(
-                existing_records=existing_records, channel="all"
+                existing_records=existing_records, channel=main.CHANNEL_ALL
             )
 
     def test_consistency_unknown_parent(self):
         existing_records = [
-            make_record("20491230-3", parent=None, channel="all"),
-            make_record("20491231-0", parent="20491230-2", channel="all"),
-            make_record("20491231-1", parent="20491231-0", channel="all"),
+            make_record("20491230-3", parent=None),
+            make_record("20491231-0", parent="20491230-2"),
+            make_record("20491231-1", parent="20491231-0"),
         ]
         with self.assertRaises(main.ConsistencyException):
             main.crlite_verify_record_consistency(
-                existing_records=existing_records, channel="all"
+                existing_records=existing_records, channel=main.CHANNEL_ALL
             )
 
     def test_consistency_nonlinear(self):
         existing_records = [
-            make_record("20491230-3", parent=None, channel="all"),
-            make_record("20491231-0", parent="20491230-3", channel="all"),
-            make_record("20491231-1", parent="20491230-3", channel="all"),
+            make_record("20491230-3", parent=None),
+            make_record("20491231-0", parent="20491230-3"),
+            make_record("20491231-1", parent="20491230-3"),
         ]
         with self.assertRaises(main.ConsistencyException):
             main.crlite_verify_record_consistency(
-                existing_records=existing_records, channel="all"
+                existing_records=existing_records, channel=main.CHANNEL_ALL
             )
 
     def test_run_id_consistency_not_sequential(self):
         with self.assertRaises(main.ConsistencyException):
-            db = MockRunDB([])
+            db = MockRunDB([], [])
             main.crlite_verify_run_id_consistency(
                 run_db=db,
                 identifiers_to_check=[
@@ -198,16 +210,16 @@ class TestPublishDecisions(unittest.TestCase):
                     "20491231-3",
                     "20500101-0",
                 ],
-                channel="all",
+                channel=main.CHANNEL_ALL,
             )
 
     def test_run_id_consistency_out_of_order(self):
         with self.assertRaises(main.ConsistencyException):
-            db = MockRunDB([])
+            db = MockRunDB([], [])
             main.crlite_verify_run_id_consistency(
                 run_db=db,
                 identifiers_to_check=["20491230-3", "20491231-1", "20491231-0"],
-                channel="all",
+                channel=main.CHANNEL_ALL,
             )
 
     def test_run_id_consistency_okay(self):
@@ -219,68 +231,79 @@ class TestPublishDecisions(unittest.TestCase):
             "20491231-3",
             "20500101-0",
         ]
-        db = MockRunDB(identifiers)
+        db = MockRunDB(identifiers, identifiers)
         main.crlite_verify_run_id_consistency(
-            run_db=db, identifiers_to_check=identifiers, channel="all"
+            run_db=db, identifiers_to_check=identifiers, channel=main.CHANNEL_ALL
         )
 
     def test_run_id_consistency_empty(self):
-        db = MockRunDB([])
+        db = MockRunDB([], [])
         main.crlite_verify_run_id_consistency(
-            run_db=db, identifiers_to_check=[], channel="all"
+            run_db=db, identifiers_to_check=[], channel=main.CHANNEL_ALL
         )
 
     def test_initial_conditions(self):
         existing_records = []
-        db = MockRunDB(["20500101-1"])
+        identifiers = ["20500101-1"]
+        db = MockRunDB(identifiers, identifiers)
         result = main.crlite_determine_publish(
-            existing_records=existing_records, run_db=db, channel="all"
+            existing_records=existing_records, run_db=db, channel=main.CHANNEL_ALL
         )
         self.assertEqual(result, {"clear_all": True, "upload": ["20500101-1"]})
 
+    def test_not_completed(self):
+        existing_records = []
+        identifiers = ["20500101-1", "20500101-2"]
+        db = MockRunDB(identifiers, identifiers[:1])
+        with self.assertRaises(main.ConsistencyException):
+            main.crlite_verify_run_id_consistency(
+                run_db=db, identifiers_to_check=identifiers, channel=main.CHANNEL_ALL
+            )
+
     def test_no_overlap(self):
         existing_records = [
-            make_record("20491231-2", parent=None, channel="all"),
-            make_record("20491231-3", parent="20491231-2", channel="all"),
+            make_record("20491231-2", parent=None),
+            make_record("20491231-3", parent="20491231-2"),
         ]
-        db = MockRunDB(["20500101-0"])
+        identifiers = ["20500101-0"]
+        db = MockRunDB(identifiers, identifiers)
         result = main.crlite_determine_publish(
-            existing_records=existing_records, run_db=db, channel="all"
+            existing_records=existing_records, run_db=db, channel=main.CHANNEL_ALL
         )
         self.assertEqual(result, {"clear_all": True, "upload": ["20500101-0"]})
 
     def test_continue_with_single_stash(self):
         existing_records = [
-            make_record("20491231-2", parent=None, channel="all"),
-            make_record("20491231-3", parent="20491231-2", channel="all"),
+            make_record("20491231-2", parent=None),
+            make_record("20491231-3", parent="20491231-2"),
         ]
-        db = MockRunDB(["20491231-2", "20491231-3", "20500101-0"])
+        identifiers = ["20491231-2", "20491231-3", "20500101-0"]
+        db = MockRunDB(identifiers, identifiers)
         result = main.crlite_determine_publish(
-            existing_records=existing_records, run_db=db, channel="all"
+            existing_records=existing_records, run_db=db, channel=main.CHANNEL_ALL
         )
         self.assertEqual(result, {"clear_all": False, "upload": ["20500101-0"]})
 
     def test_continue_with_four_stashes(self):
         existing_records = [
-            make_record("20491231-0", parent=None, channel="all"),
-            make_record("20491231-1", parent="20491231-0", channel="all"),
-            make_record("20491231-2", parent="20491231-1", channel="all"),
-            make_record("20491231-3", parent="20491231-2", channel="all"),
+            make_record("20491231-0", parent=None),
+            make_record("20491231-1", parent="20491231-0"),
+            make_record("20491231-2", parent="20491231-1"),
+            make_record("20491231-3", parent="20491231-2"),
         ]
-        db = MockRunDB(
-            [
-                "20491231-0",
-                "20491231-1",
-                "20491231-2",
-                "20491231-3",
-                "20500101-0",
-                "20500101-1",
-                "20500101-2",
-                "20500101-3",
-            ]
-        )
+        identifiers = [
+            "20491231-0",
+            "20491231-1",
+            "20491231-2",
+            "20491231-3",
+            "20500101-0",
+            "20500101-1",
+            "20500101-2",
+            "20500101-3",
+        ]
+        db = MockRunDB(identifiers, identifiers)
         result = main.crlite_determine_publish(
-            existing_records=existing_records, run_db=db, channel="all"
+            existing_records=existing_records, run_db=db, channel=main.CHANNEL_ALL
         )
         self.assertEqual(
             result,
@@ -292,61 +315,58 @@ class TestPublishDecisions(unittest.TestCase):
 
     def test_up_to_date_single_entry(self):
         existing_records = [
-            make_record("20491231-3", parent=None, channel="all"),
+            make_record("20491231-3", parent=None)
         ]
-        db = MockRunDB(
-            [
-                "20491230-1",
-                "20491230-2",
-                "20491230-3",
-                "20491231-0",
-                "20491231-1",
-                "20491231-2",
-                "20491231-3",
-            ]
-        )
+        identifiers = [
+            "20491230-1",
+            "20491230-2",
+            "20491230-3",
+            "20491231-0",
+            "20491231-1",
+            "20491231-2",
+            "20491231-3",
+        ]
+        db = MockRunDB(identifiers, identifiers)
         result = main.crlite_determine_publish(
-            existing_records=existing_records, run_db=db, channel="all"
+            existing_records=existing_records, run_db=db, channel=main.CHANNEL_ALL
         )
         self.assertEqual(result, {"clear_all": False, "upload": []})
 
     def test_up_to_date(self):
         existing_records = [
-            make_record("20491231-0", parent=None, channel="all"),
-            make_record("20491231-1", parent="20491231-0", channel="all"),
-            make_record("20491231-2", parent="20491231-1", channel="all"),
-            make_record("20491231-3", parent="20491231-2", channel="all"),
+            make_record("20491231-0", parent=None),
+            make_record("20491231-1", parent="20491231-0"),
+            make_record("20491231-2", parent="20491231-1"),
+            make_record("20491231-3", parent="20491231-2"),
         ]
-        db = MockRunDB(
-            [
-                "20491230-1",
-                "20491230-2",
-                "20491230-3",
-                "20491231-0",
-                "20491231-1",
-                "20491231-2",
-                "20491231-3",
-            ]
-        )
+        identifiers = [
+            "20491230-1",
+            "20491230-2",
+            "20491230-3",
+            "20491231-0",
+            "20491231-1",
+            "20491231-2",
+            "20491231-3",
+        ]
+        db = MockRunDB(identifiers, identifiers)
         result = main.crlite_determine_publish(
-            existing_records=existing_records, run_db=db, channel="all"
+            existing_records=existing_records, run_db=db, channel=main.CHANNEL_ALL
         )
         self.assertEqual(result, {"clear_all": False, "upload": []})
 
     def test_rundb_data_loss(self):
         existing_records = [
-            make_record("20491231-0", parent=None, channel="all"),
-            make_record("20491231-1", parent="20491231-0", channel="all"),
-            make_record("20491231-2", parent="20491231-1", channel="all"),
+            make_record("20491231-0", parent=None),
+            make_record("20491231-1", parent="20491231-0"),
+            make_record("20491231-2", parent="20491231-1"),
         ]
-        db = MockRunDB(
-            [
-                "20491231-1",
-                "20491231-2",
-            ]
-        )
+        identifiers = [
+            "20491231-1",
+            "20491231-2",
+        ]
+        db = MockRunDB(identifiers, identifiers)
         result = main.crlite_determine_publish(
-            existing_records=existing_records, run_db=db, channel="all"
+            existing_records=existing_records, run_db=db, channel=main.CHANNEL_ALL
         )
         self.assertEqual(result, {"clear_all": True, "upload": ["20491231-2"]})
 
@@ -356,12 +376,12 @@ class TestPublishDecisions(unittest.TestCase):
             date = (datetime.now() - timedelta(days=i)).strftime("%Y%m%d")
             for j in [0, 1, 2, 3]:
                 ids += [f"{date}-{j}"]
-        existing_records = [make_record(ids[0], parent=None, channel="all")]
+        existing_records = [make_record(ids[0], parent=None)]
         for i in range(1, len(ids)):
-            existing_records += [make_record(ids[i], parent=ids[i - 1], channel="all")]
-        db = MockRunDB(ids)
+            existing_records += [make_record(ids[i], parent=ids[i - 1])]
+        db = MockRunDB(ids, ids)
         result = main.crlite_determine_publish(
-            existing_records=existing_records, run_db=db, channel="all"
+            existing_records=existing_records, run_db=db, channel=main.CHANNEL_ALL
         )
         self.assertEqual(result, {"clear_all": True, "upload": [ids[-1]]})
 
@@ -371,11 +391,11 @@ class TestPublishDecisions(unittest.TestCase):
             date = (datetime.now() - timedelta(days=i)).strftime("%Y%m%d")
             for j in [0, 1, 2, 3]:
                 ids += [f"{date}-{j}"]
-        existing_records = [make_record(ids[0], parent=None, channel="all")]
+        existing_records = [make_record(ids[0], parent=None)]
         for i in range(1, len(ids)):
-            existing_records += [make_record(ids[i], parent=ids[i - 1], channel="all")]
-        db = MockRunDB(ids)
+            existing_records += [make_record(ids[i], parent=ids[i - 1])]
+        db = MockRunDB(ids, ids)
         result = main.crlite_determine_publish(
-            existing_records=existing_records, run_db=db, channel="all"
+            existing_records=existing_records, run_db=db, channel=main.CHANNEL_ALL
         )
         self.assertEqual(result, {"clear_all": False, "upload": []})


### PR DESCRIPTION
The MockRunDB class in test_publisher.py was overriding PublishedRunDB's `get_run_timestamps()`, `is_run_valid()`, and `is_run_ready()` methods, because those methods usually make network requests to google cloud storage. This has caused us to miss bugs in local testing that end up taking down our stage instance (like the typo in main.py that this PR fixes). The strategy here is to instead define a "bucket" that uses the local file system instead of GCS.