### PR TITLE
moz_kinto_publisher: refine filter expressions

### DIFF
--- a/moz_kinto_publisher/main.py
+++ b/moz_kinto_publisher/main.py
@@ -720,11 +720,11 @@ def publish_crlite_record(
         # pref, but we assign them to this channel by default.
         attributes[
             "filter_expression"
-        ] = f"env.version|versionCompare('130') < 0 || '{channel}' == 'security.pki.crlite_channel'|preferenceValue('none')"
+        ] = f"env.version|versionCompare('130.!') < 0 || '{channel}' == 'security.pki.crlite_channel'|preferenceValue('none')"
     else:
         attributes[
             "filter_expression"
-        ] = f"env.version|versionCompare('130') >= 0 && '{channel}' == 'security.pki.crlite_channel'|preferenceValue('none')"
+        ] = f"env.version|versionCompare('130.!') >= 0 && '{channel}' == 'security.pki.crlite_channel'|preferenceValue('none')"
 
     record = rw_client.create_record(
         collection=settings.KINTO_CRLITE_COLLECTION,


### PR DESCRIPTION
The version comparison we were using previously worked for "130.0.0" but not for "130.0a1", which is the format used for Nightly builds.

I noticed that Nimbus experiments use the ".!" suffix, and this works in the browser console:
```
let {FilterExpressions} = ChromeUtils.importESModule("resource://gre/modules/components-utils/FilterExpressions.sys.mjs")
let expression = "env.version|versionCompare('130.!') >= 0"
let context = {env: {version:"130.0a1"}}
await FilterExpressions.eval(expression, context) 
```