### PR TITLE
Include SCTs in rust-query-crlite output

### DIFF
--- a/rust-query-crlite/Cargo.toml
+++ b/rust-query-crlite/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 base64 = "0.13"
 bincode = "1.3"
 byteorder = "1.2.7"
-clap = { version = "3.0", features = ["derive"] }
+clap = { version = "3.2", features = ["derive"] }
 der-parser = "9.0"
 hex = "0.4"
 log = "0.4"
@@ -15,7 +15,7 @@ num-bigint = "0.4"
 pem = "1.0"
 reqwest = { version = "0.11", features = ["blocking", "json", "rustls-tls"] }
 rust_cascade = "1.4.0"
-rustls = "0.21"
+rustls = { version = "0.21", features = ["dangerous_configuration"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10.2"


### PR DESCRIPTION
Adds some debugging output that will help us diagnose issues with low coverage.

Sample output (the lines starting with DEBUG - SCT are new):
```
DEBUG - Loaded certificate from facebook.com
DEBUG - Issuer DN: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert SHA2 High Assurance Server CA
DEBUG - Serial number: 058f2602d87cfac7860bd0471b527c7a
DEBUG - Issuer SPKI hash: 936bfae7bc41b0e55ed4f411c0eb07b30ddbb064f657322acf92bee7db0d430b
DEBUG - Issuer enrollment key: Y9KTj27tGscomxSudZYfWJHcTkyXFvsyH6IybXChDzM=
DEBUG - SCT from Google 'Argon2024' log at 1714868970209 is in observed interval [1654791529771, 1721347171488].
INFO - facebook.com Good
DEBUG - Loaded certificate from en.wikipedia.org
DEBUG - Issuer DN: C=US, O=Let's Encrypt, CN=E5
DEBUG - Serial number: 045a7c883edcc31b1a400b5d23a007add957
DEBUG - Issuer SPKI hash: 3586d4ecf070578cbd27aedce20b964e48bc149faeb9dad72f46b857869172b8
DEBUG - Issuer enrollment key: va993LAfb2SYQMCTDekgmMF0Dj0xQN+QG1qOBj244sQ=
DEBUG - SCT from non-enrolled DigiCert Yeti2024 Log at 1718599929364.
DEBUG - SCT from non-enrolled Sectigo 'Mammoth2024h2' at 1718599929559.
WARN - en.wikipedia.org NotCovered
```