### PR TITLE
moz_kinto_publisher: set minimum version for experimental filter channel

### DIFF
--- a/moz_kinto_publisher/main.py
+++ b/moz_kinto_publisher/main.py
@@ -724,6 +724,11 @@ def publish_crlite_record(
         attributes[
             "filter_expression"
         ] = f"env.version|versionCompare('130.!') < 0 || '{channel}' == 'security.pki.crlite_channel'|preferenceValue('none')"
+    elif channel == CHANNEL_EXPERIMENTAL:
+        # Support for Clubcard-based CRLite filters first landed in Firefox 132
+        attributes[
+            "filter_expression"
+        ] = f"env.version|versionCompare('132.!') >= 0 && '{channel}' == 'security.pki.crlite_channel'|preferenceValue('none')"
     else:
         attributes[
             "filter_expression"


### PR DESCRIPTION
Client-side support for Clubcard-based filters landed in Firefox 132 (https://bugzilla.mozilla.org/show_bug.cgi?id=1920142).