### PR TITLE
Create filter-based delta updates

### DIFF
--- a/rust-create-cascade/src/clubcard_helper.rs
+++ b/rust-create-cascade/src/clubcard_helper.rs
@@ -94,17 +94,16 @@ impl FilterBuilder for ClubcardBuilder<4, CRLiteBuilderItem> {
             .map(|iter| iter.into())
             .unwrap_or_default();
 
-        let non_revoked_serials = known_serials.filter(|x| !revoked_serial_set.contains(x));
-
-        for serial in &revoked_serial_set {
-            let key = CRLiteBuilderItem::revoked(*issuer, decode_serial(serial));
+        for serial in known_serials {
+            let serial_bytes = decode_serial(&serial);
+            let key = if revoked_serial_set.contains(&serial) {
+                CRLiteBuilderItem::revoked(*issuer, serial_bytes)
+            } else {
+                CRLiteBuilderItem::not_revoked(*issuer, serial_bytes)
+            };
             ribbon_builder.insert(key);
         }
 
-        for serial in non_revoked_serials {
-            let key = CRLiteBuilderItem::not_revoked(*issuer, decode_serial(&serial));
-            ribbon_builder.insert(key);
-        }
         ribbon_builder.into()
     }
 

--- a/rust-create-cascade/src/clubcard_helper.rs
+++ b/rust-create-cascade/src/clubcard_helper.rs
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::{
-    decode_serial, list_issuer_file_pairs, CheckableFilter, FilterBuilder, KnownSerialIterator,
-    ReasonSet, RevokedSerialAndReasonIterator, Serial,
+    decode_issuer, decode_serial, list_issuer_file_pairs, CheckableFilter, FilterBuilder,
+    KnownSerialIterator, ReasonSet, RevokedSerialAndReasonIterator, Serial,
 };
 use clubcard::{builder::*, Clubcard};
 
@@ -64,9 +64,11 @@ impl FilterBuilder for ClubcardBuilder<4, CRLiteBuilderItem> {
                 .par_iter()
                 .map(|pair| {
                     if let (issuer, Some(revoked_file), known_file) = pair {
+                        let issuer_bytes =
+                            decode_issuer(issuer.to_str().expect("non-unicode issuer string"));
                         Some(clubcard_do_one_issuer(
                             self,
-                            issuer,
+                            &issuer_bytes,
                             RevokedSerialAndReasonIterator::new(revoked_file, reason_set),
                             KnownSerialIterator::new(known_file),
                         ))

--- a/rust-create-cascade/src/main.rs
+++ b/rust-create-cascade/src/main.rs
@@ -771,7 +771,7 @@ fn main() {
     let (delta_revoked, delta_not_revoked, delta_reasons) =
         count_all(delta_dir, known_dir, delta_reason_set);
 
-    info!("Found {} 'revoked' serial numbers in delta", delta_revoked,);
+    info!("Found {} 'revoked' serial numbers in delta", delta_revoked);
     info!("Revocation reason codes: {:#?}", delta_reasons);
 
     info!("Generating delta filter");
@@ -809,7 +809,7 @@ fn main() {
         client.gauge("not_revoked", not_revoked as f64);
         client.gauge("revoked", revoked as f64);
         client.gauge("delta_filter_size", delta_filter_bytes.len() as f64);
-        client.gauge("delta_not_revoked", not_revoked as f64);
+        client.gauge("delta_not_revoked", delta_not_revoked as f64);
         client.gauge("delta_revoked", delta_revoked as f64);
         client.gauge("revoked.unspecified", reasons.unspecified as f64);
         client.gauge("revoked.key_compromise", reasons.key_compromise as f64);

--- a/rust-create-cascade/src/main.rs
+++ b/rust-create-cascade/src/main.rs
@@ -590,6 +590,8 @@ struct Cli {
     outdir: PathBuf,
     #[clap(long, value_enum, default_value = "all")]
     reason_set: ReasonSet,
+    #[clap(long, value_enum, default_value = "all")]
+    delta_reason_set: ReasonSet,
     #[clap(long)]
     statsd_host: Option<String>,
     #[clap(long)]
@@ -617,6 +619,7 @@ fn main() {
     let revoked_dir = &args.revoked;
     let prev_revset_file = &args.prev_revset;
     let reason_set = args.reason_set;
+    let delta_reason_set = args.delta_reason_set;
     let filter_type = args.filter_type;
     let ct_logs_json = &args.ct_logs_json;
 
@@ -751,17 +754,22 @@ fn main() {
         prev_revset_file,
         revoked_dir,
         known_dir,
-        reason_set,
+        delta_reason_set,
         statsd_client.as_ref(),
     );
 
-    write_stash(stash_file, delta_dir, reason_set, statsd_client.as_ref());
+    write_stash(
+        stash_file,
+        delta_dir,
+        delta_reason_set,
+        statsd_client.as_ref(),
+    );
     let timer_finish = Instant::now() - timer_start;
     info!("Finished in {} seconds", timer_finish.as_secs());
 
     info!("Counting delta serials");
     let (delta_revoked, delta_not_revoked, delta_reasons) =
-        count_all(delta_dir, known_dir, reason_set);
+        count_all(delta_dir, known_dir, delta_reason_set);
 
     info!("Found {} 'revoked' serial numbers in delta", delta_revoked,);
     info!("Revocation reason codes: {:#?}", delta_reasons);
@@ -776,7 +784,7 @@ fn main() {
                 delta_dir,
                 known_dir,
                 ct_logs_json,
-                reason_set,
+                delta_reason_set,
             )
         }
         FilterType::Cascade => {
@@ -788,7 +796,7 @@ fn main() {
                 delta_dir,
                 known_dir,
                 hash_alg,
-                reason_set,
+                delta_reason_set,
             )
         }
     };

--- a/workflow/2-generate_mlbf
+++ b/workflow/2-generate_mlbf
@@ -23,6 +23,11 @@ parser.add_argument(
     help="Reason set [values: all, specified, priority]",
     required=False,
 )
+parser.add_argument(
+    "--delta-reason-set",
+    help="Delta reason set. Mirrors --reason-set if omitted. [values: all, specified, priority]",
+    required=False,
+)
 
 parser.add_argument(
     "--filter-type",
@@ -57,6 +62,7 @@ def main():
         cmdline += ["--statsd-host", args.statsd_host]
 
     reason_set = args.reason_set if args.reason_set else "all"
+    delta_reason_set = args.delta_reason_set if args.delta_reason_set else reason_set
     filter_type = args.filter_type if args.filter_type else "cascade"
 
     if filter_type == "cascade" and reason_set == "all":
@@ -71,6 +77,8 @@ def main():
         outdir,
         "--reason-set",
         reason_set,
+        "--delta-reason-set",
+        delta_reason_set,
         "--filter-type",
         filter_type,
     ]


### PR DESCRIPTION
Consider two successive runs of rust-create-cascade where the known-revoked certificate sets are R1 and R2, respectively, and the known certificate sets are N1 and N2, respectively. The second run of rust-create-cascade will output a full filter that encodes R2 relative to N2 and it will output a "stash file" that lists the elements of R2 \ R1.

There are two problems with stash files.
1) they are much less space efficient than filters, and
2) they don't update the coverage metadata for known non-revoked certificates.

This PR makes it so that the second run of rust-create-cascade outputs a filter that encodes R2 \ R1 relative to N2. This turns out to be much more space efficient than a stash, and (at least in the case of Clubcard filters) the new filter contains fresh coverage metadata.

A client who receives a full filter and several of these delta filters will:
1) query each of the filters.
2) return "revoked" if any of the queries returns "revoked".
3) return "good" if any of the queries returns "good".
4) return "not enrolled" if any of the queries returns "not enrolled".
5) return "not covered".

This PR does not change what we publish. I want to watch the statsd telemetry for a bit and also update Firefox Nightly before we do that.