### PR TITLE
preserve directory structure in latest directory, and add rust-query-crlite support for new channel

### DIFF
--- a/rust-create-cascade/Cargo.toml
+++ b/rust-create-cascade/Cargo.toml
@@ -15,5 +15,5 @@ statsd = "0.16.0"
 stderrlog = "0.5"
 tempfile = "3.10.1"
 clubcard = { version = "0.3", features = ["builder"] }
-clubcard-crlite = { version = "0.2", features = ["builder"] }
+clubcard-crlite = { version = "0.3", features = ["builder"] }
 serde_json = "1"

--- a/rust-create-cascade/src/clubcard_helper.rs
+++ b/rust-create-cascade/src/clubcard_helper.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use clubcard::{builder::*, Clubcard};
 
-use clubcard_crlite::{builder::*, CRLiteClubcard, CRLiteCoverage, CRLiteQuery};
+use clubcard_crlite::{builder::*, CRLiteClubcard, CRLiteCoverage, CRLiteKey, CRLiteQuery};
 
 use log::*;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
@@ -129,9 +129,10 @@ impl CheckableFilter for CRLiteClubcard {
 
         for serial in known_serials {
             let decoded_serial = decode_serial(&serial);
-            let key = CRLiteQuery::new(issuer, &decoded_serial, None);
+            let key = CRLiteKey::new(issuer, &decoded_serial);
+            let query = CRLiteQuery::new(&key, None);
             assert!(
-                Clubcard::unchecked_contains(self.as_ref(), &key)
+                Clubcard::unchecked_contains(self.as_ref(), &query)
                     == revoked_serial_set.contains(&serial)
             );
         }

--- a/rust-query-crlite/Cargo.toml
+++ b/rust-query-crlite/Cargo.toml
@@ -9,7 +9,7 @@ bincode = "1.3"
 byteorder = "1.2.7"
 clap = { version = "3.2", features = ["derive"] }
 clubcard = "0.3"
-clubcard-crlite = "0.2"
+clubcard-crlite = "0.3"
 der-parser = "9.0"
 hex = "0.4"
 log = "0.4"

--- a/rust-query-crlite/Cargo.toml
+++ b/rust-query-crlite/Cargo.toml
@@ -9,7 +9,7 @@ bincode = "1.3"
 byteorder = "1.2.7"
 clap = { version = "3.2", features = ["derive"] }
 clubcard = "0.3"
-clubcard-crlite = "0.1"
+clubcard-crlite = "0.2"
 der-parser = "9.0"
 hex = "0.4"
 log = "0.4"

--- a/rust-query-crlite/src/main.rs
+++ b/rust-query-crlite/src/main.rs
@@ -374,11 +374,8 @@ impl Filter {
                 }
             }
             Filter::Clubcard(clubcard) => {
-                match clubcard.contains(
-                    issuer_spki_hash,
-                    serial,
-                    timestamps.iter().map(|(x, y)| (x, *y)),
-                ) {
+                let crlite_key = clubcard_crlite::CRLiteKey::new(issuer_spki_hash, serial);
+                match clubcard.contains(&crlite_key, timestamps.iter().map(|(x, y)| (x, *y))) {
                     CRLiteStatus::Good => Status::Good,
                     CRLiteStatus::NotCovered => Status::NotCovered,
                     CRLiteStatus::NotEnrolled => Status::NotEnrolled,

--- a/rust-query-crlite/src/main.rs
+++ b/rust-query-crlite/src/main.rs
@@ -877,6 +877,8 @@ enum CRLiteFilterChannel {
     Specified,
     Priority,
     Experimental,
+    #[serde(rename = "experimental+deltas")]
+    ExperimentalDeltas,
 }
 
 #[derive(Clone, clap::ArgEnum)]

--- a/workflow/3-upload_mlbf_to_storage
+++ b/workflow/3-upload_mlbf_to_storage
@@ -75,7 +75,8 @@ def main():
         remoteFolder = localFolder.relative_to(runIdPath.parent)
         uploadFiles(files, localFolder, remoteFolder, bucket, args=args)
         # Add a copy to /latest
-        uploadFiles(files, localFolder, Path("latest"), bucket, args=args)
+        subFolder = localFolder.relative_to(runIdPath / "mlbf")
+        uploadFiles(files, localFolder, Path("latest") / subFolder, bucket, args=args)
 
     for path, dirs, files in os.walk(runIdPath / "mlbf-specified"):
         localFolder = Path(path)


### PR DESCRIPTION
The `3-upload_mlbf_to_storage` script wasn't preserving directory structure when it copied files from `mlbf` into `latest`, which had the annoying (but ultimately harmless) outcome of dumping all of the `mlbf/delta/<issuer>` directly into `latest` instead of `latest/delta`.

Also: make it possible for rust-query-crlite to pull from the experimental+deltas channel.