### PR TITLE
Keep an intermediate "enrolled" even when we fail to download a CRL

### DIFF
--- a/go/cmd/aggregate-known/aggregate-known.go
+++ b/go/cmd/aggregate-known/aggregate-known.go
@@ -191,23 +191,14 @@ func main() {
 
 	var count int64
 	for _, iObj := range issuerList {
-		if mozIssuers.IsIssuerEnrolled(iObj.Issuer) {
+		if mozIssuers.IsIssuerInProgram(iObj.Issuer) {
 			count = count + int64(len(iObj.ExpDates))
-		} else {
-			if mozIssuers.IsIssuerInProgram(iObj.Issuer) {
-				subj, err := mozIssuers.GetSubjectForIssuer(iObj.Issuer)
-				if err != nil {
-					glog.Error(err)
-				}
-				glog.Infof("Skipping in-program issuer ID=%s that is not enrolled: %s",
-					iObj.Issuer.ID(), subj)
-			}
 		}
 	}
 
 	workChan := make(chan knownWorkUnit, count)
 	for _, iObj := range issuerList {
-		if !mozIssuers.IsIssuerEnrolled(iObj.Issuer) {
+		if !mozIssuers.IsIssuerInProgram(iObj.Issuer) {
 			continue
 		}
 

--- a/go/rootprogram/issuers_test.go
+++ b/go/rootprogram/issuers_test.go
@@ -295,14 +295,19 @@ func Test_SaveLoadIssuersList(t *testing.T) {
 		new(big.Int).SetInt64(0))
 	enrolledIssuer := types.NewIssuer(enrolledCert)
 
-	notEnrolledCert, notEnrolledCertPem := makeCert(t, "CN=Not Enrolled Issuer", "2001-12-01",
+	notEnrolledCert, _ := makeCert(t, "CN=Not Enrolled Issuer", "2001-12-01",
 		new(big.Int).SetInt64(255))
 	notEnrolledIssuer := types.NewIssuer(notEnrolledCert)
 
 	mi := NewMozillaIssuers()
 	mi.InsertIssuerFromCertAndPem(enrolledCert, enrolledCertPem, nil)
-	mi.InsertIssuerFromCertAndPem(notEnrolledCert, notEnrolledCertPem, nil)
-	mi.Enroll(enrolledIssuer)
+
+	if !mi.IsIssuerInProgram(enrolledIssuer) {
+		t.Error("enrolledIssuer should be in program")
+	}
+	if mi.IsIssuerInProgram(notEnrolledIssuer) {
+		t.Error("notEnrolledIssuer should not be in program")
+	}
 
 	tmpfile, err := ioutil.TempFile("", "Test_SaveLoadIssuersList")
 	if err != nil {
@@ -323,33 +328,8 @@ func Test_SaveLoadIssuersList(t *testing.T) {
 	if !loadedIssuers.IsIssuerInProgram(enrolledIssuer) {
 		t.Error("enrolledIssuer should be in program")
 	}
-	if !loadedIssuers.IsIssuerInProgram(notEnrolledIssuer) {
-		t.Error("notEnrolledIssuer should be in program")
-	}
-	if !loadedIssuers.IsIssuerEnrolled(enrolledIssuer) {
-		t.Error("enrolledIssuer should be enrolled")
-	}
-	if loadedIssuers.IsIssuerEnrolled(notEnrolledIssuer) {
-		t.Error("notEnrolledIssuer should not be enrolled")
-	}
-}
-
-func Test_IsIssuerEnrolled(t *testing.T) {
-	cert, certPem := makeCert(t, "CN=Issuer", "2001-01-01",
-		new(big.Int).SetInt64(0))
-	issuer := types.NewIssuer(cert)
-
-	mi := NewMozillaIssuers()
-	mi.InsertIssuerFromCertAndPem(cert, certPem, nil)
-
-	if mi.IsIssuerEnrolled(issuer) {
-		t.Error("Should not yet be enrolled")
-	}
-
-	mi.Enroll(issuer)
-
-	if !mi.IsIssuerEnrolled(issuer) {
-		t.Error("Should now be enrolled")
+	if loadedIssuers.IsIssuerInProgram(notEnrolledIssuer) {
+		t.Error("notEnrolledIssuer should not be in program")
 	}
 }
 


### PR DESCRIPTION
We would previously "unenroll" an issuer if we failed to download one of its CRLs for an extended period of time. The thinking being that we did not want to introduce false negatives into the system. When an issuer was unenrolled, we would not include any of its certificates in our filters. So filter coverage depended on both CT log timestamps and the list of enrolled issuers.

To simplify coverage checks, we're going to remove the enrollment bit. Every issuer in Mozilla's root program will be considered enrolled. We'll invest in our CRL monitoring processes to reduce the risk that this introduces false negatives.