### PR TITLE
rust-create-cascade: treat missing revoked cert file as an empty list when constructing clubcards

### DIFF
--- a/rust-create-cascade/src/clubcard_helper.rs
+++ b/rust-create-cascade/src/clubcard_helper.rs
@@ -69,7 +69,7 @@ impl FilterBuilder for ClubcardBuilder<4, CRLiteBuilderItem> {
                         Some(revoked_file) => {
                             RevokedSerialAndReasonIterator::new(revoked_file, reason_set)
                         }
-                        None => Default::default(), // empty iterator
+                        None => RevokedSerialAndReasonIterator::empty(reason_set),
                     };
                     clubcard_do_one_issuer(
                         self,

--- a/rust-create-cascade/src/main.rs
+++ b/rust-create-cascade/src/main.rs
@@ -159,15 +159,13 @@ impl ReasonCodeHistogram {
     }
 }
 
-#[derive(clap::ValueEnum, Copy, Clone, Default)]
+#[derive(clap::ValueEnum, Copy, Clone)]
 enum ReasonSet {
-    #[default]
     All,
     Specified,
     Priority,
 }
 
-#[derive(Default)]
 struct RevokedSerialAndReasonIterator {
     lines: Option<Lines<BufReader<File>>>,
     reason_set: ReasonSet,
@@ -177,6 +175,13 @@ impl RevokedSerialAndReasonIterator {
     fn new(path: &Path, reason_set: ReasonSet) -> Self {
         Self {
             lines: Some(BufReader::new(File::open(path).unwrap()).lines()),
+            reason_set,
+        }
+    }
+
+    fn empty(reason_set: ReasonSet) -> Self {
+        Self {
+            lines: None,
             reason_set,
         }
     }

--- a/rust-create-cascade/src/main.rs
+++ b/rust-create-cascade/src/main.rs
@@ -1003,7 +1003,7 @@ mod tests {
             env.add_revoked_serial(&issuer, Reason::PrivilegeWithdrawn);
         }
 
-        let (revoked, known, dist) =
+        let (revoked, known, dist, _) =
             count_all(&env.revoked_dir(), &env.known_dir(), ReasonSet::All, None);
         assert_eq!(known, 86);
         assert_eq!(revoked, 75 + 30 + 9);
@@ -1018,7 +1018,7 @@ mod tests {
         assert_eq!(dist.privilege_withdrawn, 9);
         assert_eq!(dist.aa_compromise, 0);
 
-        let (revoked, known, dist) = count_all(
+        let (revoked, known, dist, _) = count_all(
             &env.revoked_dir(),
             &env.known_dir(),
             ReasonSet::Specified,
@@ -1037,7 +1037,7 @@ mod tests {
         assert_eq!(dist.privilege_withdrawn, 9);
         assert_eq!(dist.aa_compromise, 0);
 
-        let (revoked, known, dist) = count_all(
+        let (revoked, known, dist, _) = count_all(
             &env.revoked_dir(),
             &env.known_dir(),
             ReasonSet::Priority,
@@ -1073,7 +1073,7 @@ mod tests {
         let prev_revset_file = env.dir.path().join("old-revset.bin");
         let delta_dir = env.dir.path().join("delta");
 
-        let (revoked, not_revoked, _reasons) =
+        let (revoked, not_revoked, _reasons, _lower_bound) =
             count_all(&env.revoked_dir(), &env.known_dir(), ReasonSet::All, None);
         create_cascade(
             &filter_file,
@@ -1175,7 +1175,7 @@ mod tests {
         let filter_file = env.dir.path().join("filter");
 
         // Use ReasonSet::Specified while creating the filter
-        let (revoked, not_revoked, _reasons) = count_all(
+        let (revoked, not_revoked, _reasons, _lower_bound) = count_all(
             &env.revoked_dir(),
             &env.known_dir(),
             ReasonSet::Specified,
@@ -1213,7 +1213,7 @@ mod tests {
 
         let filter_file = env.dir.path().join("filter");
 
-        let (revoked, not_revoked, _reasons) =
+        let (revoked, not_revoked, _reasons, _lower_bound) =
             count_all(&env.revoked_dir(), &env.known_dir(), ReasonSet::All, None);
 
         let cascade_bytes = create_cascade(


### PR DESCRIPTION
The clubcard library requires you to specify a subset of the chosen universe, even if it's the empty set. In rust-create-cascade were specifying the subset in `clubcard_do_one_issuer`, but we were only calling that function if the revoked certificate file existed. Due to #324, we're now more likely to have a known cert file that does not have a matching revoked cert file. So that PR broke the generate task for clubcards.