### PR TITLE
Rework channels in moz_kinto_publisher

### DIFF
--- a/moz_kinto_publisher/main.py
+++ b/moz_kinto_publisher/main.py
@@ -66,7 +66,7 @@ CHANNELS = [
         delta_filename="filter.stash",
         supported_version=132,
         mimetype="application/octet-stream",
-        enabled=True,
+        enabled=False,
     ),
     Channel(
         slug=CHANNEL_EXPERIMENTAL_DELTAS,

--- a/moz_kinto_publisher/main.py
+++ b/moz_kinto_publisher/main.py
@@ -36,8 +36,6 @@ import settings
 #
 # NOTE: Channel names cannot contain underscores.
 CHANNEL_ALL = "all"
-CHANNEL_SPECIFIED = "specified"
-CHANNEL_PRIORITY = "priority"
 CHANNEL_EXPERIMENTAL = "experimental"
 CHANNEL_EXPERIMENTAL_DELTAS = "experimental+deltas"
 
@@ -61,22 +59,6 @@ CHANNELS = [
         supported_version=130,
         mimetype="application/octet-stream",
         enabled=True,
-    ),
-    Channel(
-        slug=CHANNEL_SPECIFIED,
-        dir="mlbf-specified",
-        delta_filename="filter.stash",
-        supported_version=130,
-        mimetype="application/octet-stream",
-        enabled=False,
-    ),
-    Channel(
-        slug=CHANNEL_PRIORITY,
-        dir="mlbf-priority",
-        delta_filename="filter.stash",
-        supported_version=130,
-        mimetype="application/octet-stream",
-        enabled=False,
     ),
     Channel(
         slug=CHANNEL_EXPERIMENTAL,

--- a/moz_kinto_publisher/main.py
+++ b/moz_kinto_publisher/main.py
@@ -1134,10 +1134,17 @@ def publish_crlite(*, args, rw_client, channel, timeout=timedelta(minutes=5)):
 
         total_stash_size = existing_stash_size + update_stash_size
         full_filter_size = filter_path.stat().st_size
-        if total_stash_size > full_filter_size:
+
+        # Legacy stash files are completely uncompressed, so if they grow too
+        # large we should publish a full filter. Clubcard-based delta updates
+        # on the other hand can compress as well or better than full filters.
+        if (
+            channel.delta_filename == "filter.stash"
+            and total_stash_size > full_filter_size
+        ):
             tasks["clear_all"] = True
         else:
-            log.info(f"New stash size: {total_stash_size} bytes")
+            log.info(f"Total stash size: {total_stash_size} bytes")
             log.info(f"New filter size: {full_filter_size} bytes")
 
     if tasks["clear_all"]:

--- a/moz_kinto_publisher/main.py
+++ b/moz_kinto_publisher/main.py
@@ -74,7 +74,7 @@ CHANNELS = [
     Channel(
         slug=CHANNEL_EXPERIMENTAL_DELTAS,
         dir="clubcard-all",
-        max_filter_age_days=10,
+        max_filter_age_days=20,
         delta_filename="filter.delta",
         supported_version=133,
         # The metadata in clubcards produced by clubcard-crlite version 0.3.*


### PR DESCRIPTION
This is a grab-bag of changes to the channels published by moz_kinto_publisher.

1) Remove the specified and priority channels entirely---all of the records associated with these channels have been removed, so there's no need to keep the definitions around.
2) Disable the `experimental` channel. This was only ever used by Nightly 133 users. It has been superseded by the experimental+deltas channel, which is also supported by 133.
3) Replace the 10-day filter age cutoff with a tunable parameter, and set it to 20 days for the experimental+deltas channel.
4) Allow the total size of delta files (but not stashes) to exceed the size of the full filter.