### PR TITLE
Stop publishing the cascade-based "all" channel and add the "default" channel

### DIFF
--- a/containers/scripts/crlite-generate.sh
+++ b/containers/scripts/crlite-generate.sh
@@ -55,12 +55,6 @@ ${workflow}/2-generate_mlbf ${ID} \
               --filter-bucket ${crlite_filter_bucket:-crlite_filters_staging} \
               --statsd-host ${statsdHost} \
               --reason-set all \
-              --filter-type cascade
-
-${workflow}/2-generate_mlbf ${ID} \
-              --filter-bucket ${crlite_filter_bucket:-crlite_filters_staging} \
-              --statsd-host ${statsdHost} \
-              --reason-set all \
               --filter-type clubcard
 
 if [ "x${DoNotUpload}x" == "xx" ] ; then

--- a/moz_kinto_publisher/main.py
+++ b/moz_kinto_publisher/main.py
@@ -60,7 +60,7 @@ CHANNELS = [
         max_filter_age_days=10,
         supported_version=130,
         mimetype="application/octet-stream",
-        enabled=True,
+        enabled=False,
     ),
     Channel(
         slug=CHANNEL_EXPERIMENTAL,

--- a/moz_kinto_publisher/main.py
+++ b/moz_kinto_publisher/main.py
@@ -38,6 +38,7 @@ import settings
 CHANNEL_ALL = "all"
 CHANNEL_EXPERIMENTAL = "experimental"
 CHANNEL_EXPERIMENTAL_DELTAS = "experimental+deltas"
+CHANNEL_DEFAULT = "default"
 
 Channel = namedtuple(
     "Channel",
@@ -75,6 +76,18 @@ CHANNELS = [
         slug=CHANNEL_EXPERIMENTAL_DELTAS,
         dir="clubcard-all",
         max_filter_age_days=20,
+        delta_filename="filter.delta",
+        supported_version=133,
+        # The metadata in clubcards produced by clubcard-crlite version 0.3.*
+        # is somewhat compressible, so set a mimetype that encourages our CDN to use
+        # compression (see: https://cloud.google.com/cdn/docs/dynamic-compression).
+        mimetype="application/x-protobuf",
+        enabled=True,
+    ),
+    Channel(
+        slug=CHANNEL_DEFAULT,
+        dir="clubcard-all",
+        max_filter_age_days=45,
         delta_filename="filter.delta",
         supported_version=133,
         # The metadata in clubcards produced by clubcard-crlite version 0.3.*

--- a/rust-query-crlite/src/main.rs
+++ b/rust-query-crlite/src/main.rs
@@ -557,7 +557,7 @@ struct Cli {
     update: Option<RemoteSettingsInstance>,
 
     /// CRLite filter channel
-    #[clap(long, value_enum, default_value = "experimental-deltas")]
+    #[clap(long, value_enum, default_value = "default")]
     channel: CRLiteFilterChannel,
 
     /// CRLite directory e.g. <firefox profile>/security_state/.
@@ -577,9 +577,10 @@ struct Cli {
 enum CRLiteFilterChannel {
     All,
     Experimental,
-    #[default]
     #[serde(rename = "experimental+deltas")]
     ExperimentalDeltas,
+    #[default]
+    Default,
 }
 
 #[derive(Clone, clap::ArgEnum)]

--- a/workflow/3-upload_mlbf_to_storage
+++ b/workflow/3-upload_mlbf_to_storage
@@ -68,30 +68,15 @@ def main():
 
     runIdPath = args.results_path[0].resolve()
 
-    ensureFileOrAbort(runIdPath, Path("mlbf/filter"))
-
-    for path, dirs, files in os.walk(runIdPath / "mlbf"):
-        localFolder = Path(path)
-        remoteFolder = localFolder.relative_to(runIdPath.parent)
-        uploadFiles(files, localFolder, remoteFolder, bucket, args=args)
-        # Add a copy to /latest
-        subFolder = localFolder.relative_to(runIdPath / "mlbf")
-        uploadFiles(files, localFolder, Path("latest") / subFolder, bucket, args=args)
-
-    for path, dirs, files in os.walk(runIdPath / "mlbf-specified"):
-        localFolder = Path(path)
-        remoteFolder = localFolder.relative_to(runIdPath.parent)
-        uploadFiles(files, localFolder, remoteFolder, bucket, args=args)
-
-    for path, dirs, files in os.walk(runIdPath / "mlbf-priority"):
-        localFolder = Path(path)
-        remoteFolder = localFolder.relative_to(runIdPath.parent)
-        uploadFiles(files, localFolder, remoteFolder, bucket, args=args)
+    ensureFileOrAbort(runIdPath, Path("clubcard-all/filter"))
 
     for path, dirs, files in os.walk(runIdPath / "clubcard-all"):
         localFolder = Path(path)
         remoteFolder = localFolder.relative_to(runIdPath.parent)
         uploadFiles(files, localFolder, remoteFolder, bucket, args=args)
+        # Add a copy to /latest
+        subFolder = localFolder.relative_to(runIdPath / "clubcard-all")
+        uploadFiles(files, localFolder, Path("latest") / subFolder, bucket, args=args)
 
     sentinel = bucket.blob(str(Path(runIdPath.name) / "completed"))
     log.info(f"Saving 'completed' marker to {sentinel.name}")


### PR DESCRIPTION
The default channel for Firefox users is going to be clubcard-based CRLite with 12 hour latency and a 45 day recompression interval. This patch adds that channel. It also removes the "all" channel, which was still based on Bloom filter cascades.

I've taken the opportunity to remove support for cascades from moz_kinto_publisher and rust-query-crlite. And I've also added support for delta clubcards to rust-query-crlite.