### PR TITLE
Remove delayed run checks

### DIFF
--- a/moz_kinto_publisher/main.py
+++ b/moz_kinto_publisher/main.py
@@ -901,14 +901,6 @@ def crlite_verify_record_consistency(*, existing_records, channel):
     if maxHeight != len(existing_records) - 1:
         raise ConsistencyException(f"Multiple filter descendents: {full_filters}")
 
-    # There should be no long gaps between record timestamps
-    allowed_delta = timedelta(hours=8)
-    timestamps = [timestamp_from_record(r) for r in existing_records]
-    for x, y in zip(timestamps, timestamps[1:]):
-        if y - x > allowed_delta:
-            raise ConsistencyException(f"Too-wide a delta: {y-x}")
-
-
 def crlite_verify_run_id_consistency(*, run_db, identifiers_to_check, channel):
     # The runs should be complete.
     for r in identifiers_to_check:
@@ -926,13 +918,6 @@ def crlite_verify_run_id_consistency(*, run_db, identifiers_to_check, channel):
     for x, y in zip(ts, ts[1:]):
         if x > y:
             raise ConsistencyException(f"Out-of-order timestamp: {ts}")
-
-    # There should be no large gaps between run timestamps.
-    allowed_delta = timedelta(hours=8)
-    for x, y in zip(ts, ts[1:]):
-        if y - x > allowed_delta:
-            raise ConsistencyException(f"Too-wide a delta: {y-x}")
-
 
 def crlite_determine_publish(*, existing_records, run_db, channel):
     assert len(run_db) > 0, "There must be run identifiers"

--- a/moz_kinto_publisher/test_publisher.py
+++ b/moz_kinto_publisher/test_publisher.py
@@ -358,19 +358,6 @@ class TestPublishDecisions(unittest.TestCase):
         self.assertEqual(None, rw_client.publish())
         self.assertEqual(db_run_ids, rw_client.get_run_ids())
 
-    def test_publish_big_stash(self):
-        # A big stash should cause us to publish a new filter
-        rw_client = MockClient()
-        db = MockRunDB()
-        # publish a full filter
-        db_run_ids = [db.add_run(filter_size=10, stash_size=0)]
-        self.assertEqual(db_run_ids[0], rw_client.publish())
-        self.assertEqual(db_run_ids, rw_client.get_run_ids())
-        # add a run with a large stash, we should publish a full filter
-        db_run_ids += [db.add_run(filter_size=10, stash_size=1000)]
-        self.assertEqual(db_run_ids[-1], rw_client.publish())
-        self.assertEqual([db_run_ids[-1]], rw_client.get_run_ids())
-
     def test_publish_delayed_run(self):
         rw_client = MockClient()
         db = MockRunDB()

--- a/moz_kinto_publisher/test_publisher.py
+++ b/moz_kinto_publisher/test_publisher.py
@@ -358,21 +358,6 @@ class TestPublishDecisions(unittest.TestCase):
         self.assertEqual(None, rw_client.publish())
         self.assertEqual(db_run_ids, rw_client.get_run_ids())
 
-    def test_publish_delayed_run(self):
-        rw_client = MockClient()
-        db = MockRunDB()
-        db_run_ids = [db.add_run()]
-        self.assertEqual(db_run_ids[0], rw_client.publish())
-        self.assertEqual(db_run_ids, rw_client.get_run_ids())
-        # add a stash from a run that was delayed
-        db_run_ids += [db.add_run(delta=timedelta(hours=12))]
-        self.assertEqual(None, rw_client.publish())
-        self.assertEqual(db_run_ids, rw_client.get_run_ids())
-        # the next consistency check will fail, and a full filter will be published
-        db_run_ids += [db.add_run()]
-        self.assertEqual(db_run_ids[2], rw_client.publish())
-        self.assertEqual([db_run_ids[2]], rw_client.get_run_ids())
-
     def test_publish_ten_day_old_filter(self):
         # a new filter should be published every 10 days
         rw_client = MockClient()


### PR DESCRIPTION
The consistency checks that ensure that the filter generation process runs at least every 8 hours are no longer needed. We have other mechanisms for ensuring that CRLite artifacts are fresh, and in any case we don't want to upload a full filter when we overshoot our latency target.

This also removes the "big stash" check, which should have been done as part of #334.