### PR TITLE
ct-fetch: update statsd configuration

### DIFF
--- a/go/engine/engine.go
+++ b/go/engine/engine.go
@@ -40,7 +40,10 @@ func GetConfiguredStorage(ctx context.Context, ctconfig *config.CTConfig, roStor
 
 func PrepareTelemetry(utilName string, ctconfig *config.CTConfig) {
 	metricsConf := metrics.DefaultConfig(utilName)
+	metricsConf.EnableHostname = false
+	metricsConf.EnableHostnameLabel = false
 	metricsConf.EnableRuntimeMetrics = false
+	metricsConf.EnableServiceLabel = false
 
 	if len(*ctconfig.StatsDHost) > 0 {
 		metricsSink, err := metrics.NewStatsdSink(fmt.Sprintf("%s:%d", *ctconfig.StatsDHost, *ctconfig.StatsDPort))


### PR DESCRIPTION
This will make it easier to configure alerts based on CT log coverage telemetry. The current configuration has `EnableHostname` set to true, which means we need to manually update the dashboard alerts w/ a new hostname when the service moves between k8s nodes.