### PR TITLE
moz_kinto_publisher: update crlite channels

### DIFF
--- a/rust-query-crlite/src/main.rs
+++ b/rust-query-crlite/src/main.rs
@@ -575,8 +575,6 @@ struct Cli {
 #[derive(clap::ValueEnum, Copy, Clone, Default, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
 enum CRLiteFilterChannel {
-    All,
-    Experimental,
     #[serde(rename = "experimental+deltas")]
     ExperimentalDeltas,
     #[default]

--- a/rust-query-crlite/src/main.rs
+++ b/rust-query-crlite/src/main.rs
@@ -42,7 +42,7 @@ const STAGE_URL: &str =
 
 const PROD_ATTACH_URL: &str = "https://firefox-settings-attachments.cdn.mozilla.net/";
 const PROD_URL: &str =
-    "https://firefox.settings.services.mozilla.com/v1/buckets/security-state/collections/";
+    "https://firefox.settings.services.mozilla.com/v1/buckets/security-state-staging/collections/";
 
 #[rustfmt::skip]
 const OID_SCT_EXTENSION: &der_parser::Oid = &oid!(1.3.6.1.4.1.11129.2.4.2);


### PR DESCRIPTION
Fully removes the `all` and `experimental` channels, leaving `experimental+deltas`, `default`, and `compat`.
Stops publishing filters on the `experimental+deltas` channel.