### PR TITLE
Revert "aggregate-known: log unknown issuers"

### DIFF
--- a/go/cmd/aggregate-known/aggregate-known.go
+++ b/go/cmd/aggregate-known/aggregate-known.go
@@ -202,7 +202,6 @@ func main() {
 	workChan := make(chan knownWorkUnit, count)
 	for _, iObj := range issuerList {
 		if !mozIssuers.IsIssuerInProgram(iObj.Issuer) {
-			glog.Infof("Skipping unknown issuer: %s", iObj.Issuer.ID())
 			continue
 		}
 


### PR DESCRIPTION
This is actually very noisy and not as helpful as I'd hoped.