### PR TITLE
moz_kinto_publisher: enroll new CT logs in CRLite monitoring by default

### DIFF
--- a/moz_kinto_publisher/main.py
+++ b/moz_kinto_publisher/main.py
@@ -1116,7 +1116,7 @@ def publish_ctlogs(*, args, rw_client):
     upstream_logs = [
         {
             "admissible": ctlog["admissible"],
-            "crlite_enrolled": False,
+            "crlite_enrolled": True,
             "description": ctlog["description"],
             "key": ctlog["key"],
             "logID": ctlog["log_id"],


### PR DESCRIPTION
This will cause us to automatically start monitoring CT logs when they appear in Google's collection. We were previously enrolling logs manually, mostly due to concerns about running up against our Redis memory limit. This is no longer a concern after #333.