### PR TITLE
Improve selection of local download filepath for CRLs

### DIFF
--- a/go/cmd/aggregate-crls/aggregate-crls.go
+++ b/go/cmd/aggregate-crls/aggregate-crls.go
@@ -42,7 +42,7 @@ var (
 	auditpath    = flag.String("auditpath", "<path>", "output JSON audit report")
 	ctconfig     = config.NewCTConfig()
 
-	illegalPath = regexp.MustCompile(`[^[:alnum:]\~\-\./]`)
+	illegalPath = regexp.MustCompile(`[^[:alnum:]\~\-\.]`)
 
 	allowableAgeOfLocalCRL, _ = time.ParseDuration("336h")
 )
@@ -56,6 +56,9 @@ type AggregateEngine struct {
 
 func makeFilenameFromUrl(crlUrl url.URL) string {
 	filename := fmt.Sprintf("%s-%s", crlUrl.Hostname(), path.Base(crlUrl.Path))
+	if len(crlUrl.RawQuery) > 0 {
+		filename = fmt.Sprintf("%s-%s", filename, crlUrl.RawQuery)
+	}
 	filename = strings.ToLower(filename)
 	filename = illegalPath.ReplaceAllString(filename, "")
 

--- a/go/cmd/aggregate-crls/aggregate-crls_test.go
+++ b/go/cmd/aggregate-crls/aggregate-crls_test.go
@@ -27,6 +27,39 @@ import (
 )
 
 func Test_makeFilenameFromUrl(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "Test_makeFilenameFromUrlTest")
+	if err != nil {
+		t.Error(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	checkOpenable := func(t *testing.T, tmpDir, crlUrl string) {
+		url, _ := url.Parse(crlUrl)
+
+		path := filepath.Join(tmpDir, makeFilenameFromUrl(*url))
+
+		_, err := os.OpenFile(path, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644)
+		if err != nil {
+			t.Errorf("Could not open file: %s", err)
+		}
+	}
+
+	for _, url := range []string{
+		"http://example.com/",
+		"http://example.com/?",
+		"http://example.com/?abc",
+		"http://example.com/crl/",
+		"http://example.com/crl/?",
+		"http://example.com/crl/?abc",
+		"http://example.com/~crl/",
+		"http://example.com/~crl/?",
+		"http://example.com/~crl/?abc",
+	} {
+		checkOpenable(t, tmpDir, url)
+	}
+}
+
+func Test_makeFilenameFromUrlCollisions(t *testing.T) {
 	names := make(map[string]bool)
 
 	checkCollision := func(t *testing.T, list []string, db map[string]bool) {

--- a/go/cmd/aggregate-crls/aggregate-crls_test.go
+++ b/go/cmd/aggregate-crls/aggregate-crls_test.go
@@ -38,10 +38,11 @@ func Test_makeFilenameFromUrl(t *testing.T) {
 
 		path := filepath.Join(tmpDir, makeFilenameFromUrl(*url))
 
-		_, err := os.OpenFile(path, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644)
+		f, err := os.OpenFile(path, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {
 			t.Errorf("Could not open file: %s", err)
 		}
+		f.Close()
 	}
 
 	for _, url := range []string{


### PR DESCRIPTION
We would previously try to store a CRL from `crlUrl` in a local file that contained the `path.Base(crlUrl.Path)` in its filename. This can include a `/` character in some situations, which can cause problems.

For example, we would map `http://example.com/?abc` to `example.com-/-<hash>.crl`, and we would fail to open this file for writing because the directory `example.com-` did not exist.

It would suffice to store files in `<hash>.crl`, but we want some human readable information in the filename for manual debugging.

This PR makes two changes to how we choose filenames from URLs:
* we now remove `/` characters,
* we append the query portion of the URL if it's non-empty. This makes it easier to distinguish CRLs from `http://example.com/?a` and `http://example.com/?b`.