### PR TITLE
Validate issuing dp

### DIFF
--- a/go/cmd/aggregate-crls/crl-auditor.go
+++ b/go/cmd/aggregate-crls/crl-auditor.go
@@ -24,6 +24,7 @@ var (
 	AuditKindOld                CrlAuditEntryKind = "Not Fresh, Warning"
 	AuditKindExpired            CrlAuditEntryKind = "Expired, Allowed"
 	AuditKindValid              CrlAuditEntryKind = "Valid, Processed"
+	AuditKindWrongDP            CrlAuditEntryKind = "Wrong distribution point"
 )
 
 type CrlAuditEntryKind string
@@ -169,6 +170,22 @@ func (auditor *CrlAuditor) FailedVerifyPath(issuer downloader.DownloadIdentifier
 		Errors:        []string{err.Error()},
 	})
 }
+
+func (auditor *CrlAuditor) WrongIssuingDistributionPoint(issuer downloader.DownloadIdentifier, crlUrl *url.URL, crlPath string, err error) {
+	auditor.mutex.Lock()
+	defer auditor.mutex.Unlock()
+
+	auditor.Entries = append(auditor.Entries, CrlAuditEntry{
+		Timestamp:     time.Now().UTC(),
+		Kind:          AuditKindWrongDP,
+		Url:           crlUrl.String(),
+		Path:          crlPath,
+		Issuer:        issuer,
+		IssuerSubject: auditor.getSubject(issuer),
+		Errors:        []string{err.Error()},
+	})
+}
+
 func (auditor *CrlAuditor) FailedProcessLocal(issuer downloader.DownloadIdentifier, crlUrl *url.URL, crlPath string, err error) {
 	auditor.mutex.Lock()
 	defer auditor.mutex.Unlock()

--- a/go/rootprogram/issuers.go
+++ b/go/rootprogram/issuers.go
@@ -34,7 +34,8 @@ type issuerCert struct {
 }
 
 type IssuerData struct {
-	certs []issuerCert
+	certs               []issuerCert
+	usesPartitionedCrls bool
 }
 
 type EnrolledIssuer struct {
@@ -233,7 +234,7 @@ func (mi *MozIssuers) LoadEnrolledIssuers(filePath string) error {
 		if err != nil {
 			return err
 		}
-		mi.InsertIssuerFromCertAndPem(cert, ei.Pem, nil)
+		mi.InsertIssuerFromCertAndPem(cert, ei.Pem, nil, false)
 	}
 
 	return nil
@@ -266,6 +267,17 @@ func (mi *MozIssuers) GetSubjectForIssuer(aIssuer types.Issuer) (string, error) 
 	return entry.certs[0].subjectDN, nil
 }
 
+func (mi *MozIssuers) GetUsesPartitionedCrlsForIssuer(aIssuer types.Issuer) (bool, error) {
+	mi.mutex.Lock()
+	defer mi.mutex.Unlock()
+
+	entry, ok := mi.issuerMap[aIssuer.ID()]
+	if !ok {
+		return false, fmt.Errorf("Unknown issuer: %s", aIssuer.ID())
+	}
+	return entry.usesPartitionedCrls, nil
+}
+
 func decodeCertificateFromPem(aPem string) (*x509.Certificate, error) {
 	block, rest := pem.Decode([]byte(aPem))
 
@@ -290,7 +302,8 @@ func decodeCertificateFromRow(aColMap map[string]int, aRow []string, aLineNum in
 	return cert, nil
 }
 
-func decodeCrlsFromRow(aColMap map[string]int, aRow []string, aLineNum int) ([]string, error) {
+func decodeCrlsFromRow(aColMap map[string]int, aRow []string, aLineNum int) ([]string, bool, error) {
+	usesPartitionedCrls := false
 	crls := []string{}
 	fullCrlStr := aRow[aColMap["Full CRL Issued By This CA"]]
 	fullCrlStr = strings.TrimSpace(fullCrlStr)
@@ -313,6 +326,14 @@ func decodeCrlsFromRow(aColMap map[string]int, aRow []string, aLineNum int) ([]s
 		if crl == "" {
 			continue
 		}
+
+		// If an issuer has populated its "JSON Array of Partitioned
+		// CRLs" field, then we need to validate the
+		// issuingDistributionPoint extension in each of its CRLs. If
+		// we've gotten here then there is at least one entry in the
+		// JSON Array field.
+		usesPartitionedCrls = true
+
 		crlUrl, err := url.Parse(crl)
 		if err != nil {
 			glog.Warningf("decodeCrlsFromRow: Line %d: Could not parse %q as URL: %v", aLineNum, crl, err)
@@ -323,10 +344,10 @@ func decodeCrlsFromRow(aColMap map[string]int, aRow []string, aLineNum int) ([]s
 		}
 	}
 
-	return crls, nil
+	return crls, usesPartitionedCrls, nil
 }
 
-func (mi *MozIssuers) InsertIssuerFromCertAndPem(aCert *x509.Certificate, aPem string, crls []string) types.Issuer {
+func (mi *MozIssuers) InsertIssuerFromCertAndPem(aCert *x509.Certificate, aPem string, aCrls []string, aUsesPartitionedCrls bool) types.Issuer {
 	issuer := types.NewIssuer(aCert)
 	ic := issuerCert{
 		cert:      aCert,
@@ -338,7 +359,7 @@ func (mi *MozIssuers) InsertIssuerFromCertAndPem(aCert *x509.Certificate, aPem s
 	if !exists {
 		crlSet = make(map[string]bool, 0)
 	}
-	for _, crl := range crls {
+	for _, crl := range aCrls {
 		crlSet[crl] = true
 	}
 	mi.CrlMap[issuer.ID()] = crlSet
@@ -352,7 +373,8 @@ func (mi *MozIssuers) InsertIssuerFromCertAndPem(aCert *x509.Certificate, aPem s
 	}
 
 	mi.issuerMap[issuer.ID()] = IssuerData{
-		certs: []issuerCert{ic},
+		certs:               []issuerCert{ic},
+		usesPartitionedCrls: aUsesPartitionedCrls,
 	}
 
 	return issuer
@@ -400,12 +422,12 @@ func (mi *MozIssuers) parseCCADB(aStream io.Reader) error {
 			return err
 		}
 
-		crls, err := decodeCrlsFromRow(columnMap, row, lineNum)
+		crls, usesPartitionedCrls, err := decodeCrlsFromRow(columnMap, row, lineNum)
 		if err != nil {
 			return err
 		}
 
-		_ = mi.InsertIssuerFromCertAndPem(cert, strings.Trim(row[columnMap["PEM"]], "'"), crls)
+		_ = mi.InsertIssuerFromCertAndPem(cert, strings.Trim(row[columnMap["PEM"]], "'"), crls, usesPartitionedCrls)
 		lineNum += strings.Count(strings.Join(row, ""), "\n")
 	}
 

--- a/go/rootprogram/issuers.go
+++ b/go/rootprogram/issuers.go
@@ -39,10 +39,11 @@ type IssuerData struct {
 }
 
 type EnrolledIssuer struct {
-	UniqueID   string `json:"uniqueID"`
-	PubKeyHash string `json:"pubKeyHash"`
-	Subject    string `json:"subject"`
-	Pem        string `json:"pem"`
+	UniqueID            string `json:"uniqueID"`
+	PubKeyHash          string `json:"pubKeyHash"`
+	Subject             string `json:"subject"`
+	Pem                 string `json:"pem"`
+	UsesPartitionedCrls bool   `json:"usesPartitionedCrls"`
 }
 
 type MozIssuers struct {
@@ -188,10 +189,11 @@ func (mi *MozIssuers) SaveIssuersList(filePath string) error {
 			pubKeyHash := sha256.Sum256(cert.cert.RawSubjectPublicKeyInfo)
 			uniqueID := sha256.Sum256(append(cert.cert.RawSubject, cert.cert.RawSubjectPublicKeyInfo...))
 			issuers = append(issuers, EnrolledIssuer{
-				UniqueID:   base64.URLEncoding.EncodeToString(uniqueID[:]),
-				PubKeyHash: base64.URLEncoding.EncodeToString(pubKeyHash[:]),
-				Subject:    cert.subjectDN,
-				Pem:        normalizePem(cert.pemInfo),
+				UniqueID:            base64.URLEncoding.EncodeToString(uniqueID[:]),
+				PubKeyHash:          base64.URLEncoding.EncodeToString(pubKeyHash[:]),
+				Subject:             cert.subjectDN,
+				Pem:                 normalizePem(cert.pemInfo),
+				UsesPartitionedCrls: val.usesPartitionedCrls,
 			})
 			certCount++
 		}
@@ -234,7 +236,7 @@ func (mi *MozIssuers) LoadEnrolledIssuers(filePath string) error {
 		if err != nil {
 			return err
 		}
-		mi.InsertIssuerFromCertAndPem(cert, ei.Pem, nil, false)
+		mi.InsertIssuerFromCertAndPem(cert, ei.Pem, nil, ei.UsesPartitionedCrls)
 	}
 
 	return nil

--- a/go/rootprogram/issuers_test.go
+++ b/go/rootprogram/issuers_test.go
@@ -300,7 +300,7 @@ func Test_SaveLoadIssuersList(t *testing.T) {
 	notEnrolledIssuer := types.NewIssuer(notEnrolledCert)
 
 	mi := NewMozillaIssuers()
-	mi.InsertIssuerFromCertAndPem(enrolledCert, enrolledCertPem, nil)
+	mi.InsertIssuerFromCertAndPem(enrolledCert, enrolledCertPem, nil, false)
 
 	if !mi.IsIssuerInProgram(enrolledIssuer) {
 		t.Error("enrolledIssuer should be in program")

--- a/workflow/0-allocate_identifier
+++ b/workflow/0-allocate_identifier
@@ -20,7 +20,8 @@ if not args.path:
     parser.print_usage()
     sys.exit(0)
 
-dateprefix = datetime.utcnow().date().strftime("%Y%m%d")
+now = datetime.datetime.now(datetime.UTC)
+dateprefix = now.strftime("%Y%m%d")
 next_idx = 0
 
 all_identifiers = workflow.get_run_identifiers(args.filter_bucket)
@@ -36,8 +37,6 @@ allocatedPath = args.path / Path(allocatedName)
 allocatedPath.mkdir()
 
 timestamp_file = allocatedPath / Path("timestamp")
-timestamp_file.write_text(
-    datetime.utcnow().isoformat(timespec="seconds"), encoding="utf-8"
-)
+timestamp_file.write_text(now.isoformat(timespec="seconds"), encoding="utf-8")
 
 print(allocatedPath)


### PR DESCRIPTION
Add a new CRL audit entry type for when a Partitioned CRL's `issuingDistributionPoint` extension does not match the URL that the CRL was fetched from.

Resolves #356.