### PR TITLE
ct-fetch: use new sunlight.Client.Fetcher().ReadEndpoint

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,7 +1,7 @@
 module github.com/mozilla/crlite/go
 
 require (
-	filippo.io/sunlight v0.5.1
+	filippo.io/sunlight v0.5.2
 	filippo.io/torchwood v0.5.1-0.20250713221105-b067ac9d4cf6
 	github.com/bluele/gcache v0.0.0-20190518031135-bc40bd653833
 	github.com/go-redis/redis v6.15.9+incompatible

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,5 +1,5 @@
-filippo.io/sunlight v0.5.1 h1:aLZ6JvTWP3pMQZWEK1Wss4dUAIdFi2F9gmFGzzet3xs=
-filippo.io/sunlight v0.5.1/go.mod h1:1wUWZmC0tYtzP0PC2rsegshLsLYZ6sgFSe4Utj33Tyg=
+filippo.io/sunlight v0.5.2 h1:n1aHo9ax1QvG91RrPcyFZ7F2pT7hTgywvpfytqlJiW0=
+filippo.io/sunlight v0.5.2/go.mod h1:1wUWZmC0tYtzP0PC2rsegshLsLYZ6sgFSe4Utj33Tyg=
 filippo.io/torchwood v0.5.1-0.20250713221105-b067ac9d4cf6 h1:feb1i6byodl8n5WEJJ1fafcP3eVBiiVloh3mYvnRmJY=
 filippo.io/torchwood v0.5.1-0.20250713221105-b067ac9d4cf6/go.mod h1:Z+iz3Syg0RCaVkL9nBjG2STp/9HpuFl1+SbaNSZ/Ez8=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=


### PR DESCRIPTION
I noticed your client from the User-Agent logs, and thought it was silly to make you reimplement ReadEndpoint, so I exposed it on the Client.