### PR TITLE
ct-fetch: advance MaxTimestamp with STH timestamp for fully ingested logs

### DIFF
--- a/go/cmd/ct-fetch/ct-fetch.go
+++ b/go/cmd/ct-fetch/ct-fetch.go
@@ -274,7 +274,8 @@ const (
 	Backfill                         // Download old certs
 	Update                           // Download new certs
 	ForceUpdate                      // Download new certs even if doing so will fetch a partial tile
-	Sleep                            // Wait for an STH update
+	Sleep                            // Wait for new entries
+	RetryGetSTH                      // Sleep and then try getting the STH / Checkpoint again
 )
 
 type EnrolledLogs struct {


### PR DESCRIPTION
Currently, the coverage cutoff timestamp for a CRLite filter is set to `MaxTimestamp - MMD` where `MaxTimestamp` is the largest timestamp seen in a particular CT log and `MMD` is the merge delay of that log. The coverage cutoff timestamp will advance in time as long as the log is receiving new entries. But once a log stops receiving entries it will stop advancing, and the entries of the log with timestamps within 1 MMD of the final value will never be considered to be covered.

This patch has us set `MaxTimestamp` equal to the timestamp of the latest STH when we have ingested all entries of the log.

The following requirements laid out in Section 3.5 of RFC 6962 ensure that this works. First, the RFC requires the STH timestamp to be monotonically increasing and always at least as recent as the most recent SCT timestamp:
>   "timestamp" is the current time.  The timestamp MUST be at least as
>   recent as the most recent SCT timestamp in the tree.  Each subsequent
>   timestamp MUST be more recent than the timestamp of the previous
>   update.

Second, the RFC requires the log to produce STHs with recent timestamps even if no new entries are logged:
>   Each log MUST produce on demand a Signed Tree Head that is no older
>   than the Maximum Merge Delay.  In the unlikely event that it receives
>   no new submissions during an MMD period, the log SHALL sign the same
>   Merkle Tree Hash with a fresh timestamp.
