### PR TITLE
storage: hold serials in cache until they are covered

### DIFF
--- a/go/cmd/aggregate-known/aggregate-known.go
+++ b/go/cmd/aggregate-known/aggregate-known.go
@@ -86,16 +86,8 @@ func (kw knownWorker) run(ctx context.Context, wg *sync.WaitGroup, workChan <-ch
 				if err != nil {
 					glog.Fatalf("[%s] Could not read serials with expDate=%s: %s", tuple.issuer.ID(), expDate.ID(), err)
 				}
-				knownSetLen := uint64(len(knownSet))
 
-				if knownSetLen == 0 {
-					// This is almost certainly due to an hour-rollover since the loader ran, and expired all the next hour's
-					// certs.
-					glog.Warningf("No cached certificates for issuer=%s (%s) expDate=%s, but the loader thought there should be."+
-						" (current count this worker=%d)", tuple.issuerDN, tuple.issuer.ID(), expDate, serialCount)
-				}
-
-				serialCount += knownSetLen
+				serialCount += uint64(len(knownSet))
 				err = storage.WriteSerialList(writer, expDate, tuple.issuer, knownSet)
 				if err != nil {
 					glog.Fatalf("[%s] Could not write serials: %s", tuple.issuer.ID(), err)

--- a/go/cmd/ct-fetch/ct-fetch.go
+++ b/go/cmd/ct-fetch/ct-fetch.go
@@ -61,6 +61,8 @@ var (
 type LogSyncMessage struct {
 	Certificate *x509.Certificate
 	Issuer      *x509.Certificate
+	Timestamp   uint64
+	LogId       [32]byte
 	LogState    *types.CTLogState
 }
 
@@ -234,7 +236,7 @@ func (ld *LogSyncEngine) insertCTWorker(ctx context.Context) {
 		}
 
 		if ep.Certificate != nil && ep.Issuer != nil {
-			item := ld.database.PrepareSetMember(ep.Certificate, ep.Issuer)
+			item := ld.database.PrepareSetMember(ep.Certificate, ep.Issuer, ep.Timestamp, ep.LogId)
 			queue = append(queue, item)
 		}
 

--- a/go/storage/certdatabase.go
+++ b/go/storage/certdatabase.go
@@ -276,11 +276,11 @@ func (db *CertDatabase) GetLogState(aUrl *url.URL) (*types.CTLogState, error) {
 	}, nil
 }
 
-func (db *CertDatabase) PrepareSetMember(aCertificate, aIssuer *x509.Certificate) SetMemberWithExpiry {
+func (db *CertDatabase) PrepareSetMember(aCertificate, aIssuer *x509.Certificate, aTimestamp uint64, aLogId [32]byte) SetMemberWithExpiry {
 	expDate := types.NewExpDateFromTime(aCertificate.NotAfter)
 	issuer := types.NewIssuer(aIssuer)
 	serial := types.NewSerial(aCertificate)
-	return db.GetSerialCacheKey(expDate, issuer).NewMember(serial)
+	return db.GetSerialCacheKey(expDate, issuer).NewMember(aTimestamp, aLogId, serial)
 }
 
 func (db *CertDatabase) Store(items []SetMemberWithExpiry) error {
@@ -359,7 +359,7 @@ func (db *CertDatabase) GetSerialCacheKey(aExpDate types.ExpDate, aIssuer types.
 	return kc
 }
 
-func (db *CertDatabase) ReadSerialsFromCache(aExpDate types.ExpDate, aIssuer types.Issuer) []types.Serial {
+func (db *CertDatabase) ReadEntriesFromCache(aExpDate types.ExpDate, aIssuer types.Issuer) map[string]struct{} {
 	return db.List(db.GetSerialCacheKey(aExpDate, aIssuer))
 }
 
@@ -399,10 +399,31 @@ func (db *CertDatabase) ReadSerialsFromStorage(aExpDate types.ExpDate, aIssuer t
 	return serialList, nil
 }
 
-func (db *CertDatabase) moveOneBinOfCachedSerialsToStorage(aTmpDir string, aExpDate types.ExpDate, aIssuer types.Issuer) error {
-	cachedSerials := db.ReadSerialsFromCache(aExpDate, aIssuer)
-	if len(cachedSerials) == 0 {
+func (db *CertDatabase) moveOneBinOfCachedSerialsToStorage(aTmpDir string, aExpDate types.ExpDate, aIssuer types.Issuer, aLogData []types.CTLogState) error {
+	cachedEntries := db.ReadEntriesFromCache(aExpDate, aIssuer)
+	if len(cachedEntries) == 0 {
 		return nil
+	}
+
+	// The "known set" input to the filter generation process should be the set of
+	// covered serials. Any serials that are not yet covered should stay in cache.
+	// See: https://github.com/mozilla/crlite/issues/367
+	coverageCutoffMap := types.NewCoverageCutoffMap(aLogData)
+
+	coveredEntries := make([]string, 0, len(cachedEntries))
+	coveredSerials := make([]types.Serial, 0, len(cachedEntries))
+	for entryStr := range cachedEntries {
+		entry := SerialCacheEntry(entryStr)
+		if !entry.IsCovered(&coverageCutoffMap) {
+			continue
+		}
+		serial, err := entry.AsSerial()
+		if err != nil {
+			glog.Errorf("Failed to parse serial str=[%s] %v", entryStr, err)
+			continue
+		}
+		coveredEntries = append(coveredEntries, entryStr)
+		coveredSerials = append(coveredSerials, serial)
 	}
 
 	storedSerials, err := db.ReadSerialsFromStorage(aExpDate, aIssuer)
@@ -411,7 +432,7 @@ func (db *CertDatabase) moveOneBinOfCachedSerialsToStorage(aTmpDir string, aExpD
 	}
 
 	// Concatenate the serial lists and remove any duplicates
-	serials := append(storedSerials, cachedSerials...)
+	serials := append(storedSerials, coveredSerials...)
 	serials = types.SerialList(serials).Dedup()
 
 	// Write the merged serial list to a temporary file, and atomically
@@ -433,9 +454,9 @@ func (db *CertDatabase) moveOneBinOfCachedSerialsToStorage(aTmpDir string, aExpD
 		return err
 	}
 
-	// It's now safe to remove cachedSerials from the cache.
+	// It's now safe to remove coveredEntries from the cache.
 	key := db.GetSerialCacheKey(aExpDate, aIssuer)
-	err = db.RemoveMany(key, cachedSerials)
+	err = db.RemoveMany(key, coveredEntries)
 	if err != nil {
 		glog.Warningf("Failed to remove serial from cache: %s", err)
 	}
@@ -443,7 +464,7 @@ func (db *CertDatabase) moveOneBinOfCachedSerialsToStorage(aTmpDir string, aExpD
 	return nil
 }
 
-func (db *CertDatabase) moveCachedSerialsToStorage() error {
+func (db *CertDatabase) moveCachedSerialsToStorage(aLogData []types.CTLogState) error {
 	issuerList, err := db.GetIssuerAndDatesFromCache()
 	if err != nil {
 		return err
@@ -467,7 +488,7 @@ func (db *CertDatabase) moveCachedSerialsToStorage() error {
 			wg.Add(batchSize)
 			for i := start; i < start+batchSize; i++ {
 				go func(expDate types.ExpDate) {
-					errChan <- db.moveOneBinOfCachedSerialsToStorage(tmpDir, expDate, issuer)
+					errChan <- db.moveOneBinOfCachedSerialsToStorage(tmpDir, expDate, issuer, aLogData)
 					wg.Done()
 				}(issuerDate.ExpDates[i])
 			}
@@ -642,7 +663,7 @@ func (db *CertDatabase) Commit(aProofOfLock string) error {
 		return err
 	}
 
-	err = db.moveCachedSerialsToStorage()
+	err = db.moveCachedSerialsToStorage(logList)
 	if err != nil {
 		return err
 	}
@@ -701,42 +722,34 @@ func (db *CertDatabase) AddPreIssuerAlias(aPreIssuer types.Issuer, aIssuer types
 
 // Returns true if this serial was unknown. Subsequent calls with the same serial
 // will return false, as it will be known then.
-func (db *CertDatabase) Insert(k *SerialCacheKey, aSerial types.Serial) (bool, error) {
-	result, err := db.cache.SetInsert(k.ID(), aSerial.BinaryString())
+//
+// This is currently only used in tests.
+func (db *CertDatabase) Insert(aEntry SetMemberWithExpiry) (bool, error) {
+	result, err := db.cache.SetInsert(aEntry.Key, aEntry.Value)
 	if err != nil {
 		return false, err
 	}
 
-	if !k.expirySet {
-		expireTime := k.expDate.ExpireTime()
-		if err := db.cache.ExpireAt(k.ID(), expireTime); err != nil {
-			glog.Errorf("Couldn't set expiration time %v for serials %s: %v", expireTime, k.ID(), err)
-		} else {
-			k.expirySet = true
-		}
+	if err := db.cache.ExpireAt(aEntry.Key, aEntry.Expiry); err != nil {
+		glog.Errorf("Couldn't set expiration time %v for serials %s: %v", aEntry.Expiry, aEntry.Key, err)
 	}
 
 	return result, nil
 }
 
-func (db *CertDatabase) RemoveMany(k *SerialCacheKey, aSerials []types.Serial) error {
+func (db *CertDatabase) RemoveMany(k *SerialCacheKey, aEntries []string) error {
 	// Removing an element of a set may leave the set empty. Redis
 	// automatically deletes empty sets, so assume that we need to reset
 	// the ExpireAt time for this set on the next Insert call.
 	k.expirySet = false
-	serialStrings := make([]string, len(aSerials))
-	for i := 0; i < len(aSerials); i++ {
-		serialStrings[i] = aSerials[i].BinaryString()
-	}
-	return db.cache.SetRemove(k.ID(), serialStrings)
+	return db.cache.SetRemove(k.ID(), aEntries)
 }
 
-func (db *CertDatabase) List(k *SerialCacheKey) []types.Serial {
+func (db *CertDatabase) List(k *SerialCacheKey) map[string]struct{} {
 	// Redis' scan methods regularly provide duplicates. The duplication
 	// happens at this level, pulling from SetToChan, so we make a hash-set
 	// here to de-duplicate when the memory impacts are the most minimal.
-	serials := make(map[string]struct{})
-	var count int
+	uniqueEntries := make(map[string]struct{})
 
 	strChan := make(chan string)
 	go func() {
@@ -747,19 +760,8 @@ func (db *CertDatabase) List(k *SerialCacheKey) []types.Serial {
 	}()
 
 	for str := range strChan {
-		serials[str] = struct{}{}
-		count += 1
+		uniqueEntries[str] = struct{}{}
 	}
 
-	serialList := make([]types.Serial, 0, count)
-	for str := range serials {
-		bs, err := types.NewSerialFromBinaryString(str)
-		if err != nil {
-			glog.Errorf("Failed to populate serial str=[%s] %v", str, err)
-			continue
-		}
-		serialList = append(serialList, bs)
-	}
-
-	return serialList
+	return uniqueEntries
 }

--- a/go/storage/types.go
+++ b/go/storage/types.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"encoding/binary"
 	"fmt"
 	"time"
 
@@ -52,10 +53,18 @@ func (k *SerialCacheKey) ID() string {
 	return k.id
 }
 
-func (k *SerialCacheKey) NewMember(serial types.Serial) SetMemberWithExpiry {
+func (k *SerialCacheKey) NewMember(aTimestamp uint64, aLogId [32]byte, serial types.Serial) SetMemberWithExpiry {
+	binarySerial := serial.BinaryString()
+
+	// The set member is the concatenation of the timestamp, logID, and serial number
+	value := make([]byte, 8+32+len(binarySerial))
+	binary.LittleEndian.PutUint64(value, aTimestamp)
+	copy(value[8:40], aLogId[:])
+	copy(value[40:], binarySerial)
+
 	return SetMemberWithExpiry{
 		Key:    k.ID(),
-		Value:  serial.BinaryString(),
+		Value:  string(value),
 		Expiry: k.expDate.ExpireTime(),
 	}
 }
@@ -64,4 +73,38 @@ type SetMemberWithExpiry struct {
 	Key    string
 	Value  string
 	Expiry time.Time
+}
+
+type SerialCacheEntry string
+
+func (s SerialCacheEntry) AsSerial() (types.Serial, error) {
+	if len(s) < 40 {
+		// The entire entry is a serial number
+		serial, err := types.NewSerialFromBinaryString(string(s))
+		return serial, err
+	}
+	serial, err := types.NewSerialFromBinaryString(string(s[40:]))
+	return serial, err
+}
+
+func (s SerialCacheEntry) IsCovered(aCoverageMap *types.CoverageCutoffMap) bool {
+	if len(s) < 40 {
+		// This is a raw serial number with no CT log timestamp. We
+		// need to treat it as covered to ensure that it moves to
+		// storage. This may cause us to mask a revoked serial with a
+		// "not covered" status.
+		return true
+	}
+	timestamp := binary.LittleEndian.Uint64([]byte(s[0:8]))
+	logId := []byte(s[8:40])
+
+	cutoff, prs := (*aCoverageMap)[[32]byte(logId)]
+	if !prs {
+		// Unclear how we learned about this serial number if there's
+		// no matching log, but it's definitely not covered. The cache
+		// entry will persist until the log is added or the certificate
+		// expires.
+		return false
+	}
+	return timestamp <= cutoff
 }


### PR DESCRIPTION
This changes the redis cache so that it holds tuples (timestamp, log id, serial) rather than raw serials. It also changes the Commit process so that cache entries are only moved to storage if the MaxTimestamp for the corresponding log is at least one MMD ahead of the timestamp value for the entry.

One minor hangup is that the cache will hold serial numbers in the legacy format when we roll this out. The baseline requirements say that serial numbers cannot be more than 20 bytes. So we can identify legacy cache entries by their length (timestamp is 8 bytes and log id is 32, so new cache entries are at least 40 bytes).

There could be a legacy cache entry that is in violation of the BRs and is more than 40 bytes. Such an entry will persist in cache until the corresponding certificate expires. There will be a risk that CRLite filters give it the wrong status. The risk here is quite low as such a certificate would need to be issued in the 12 hour period when we roll this out. And also the BRs would require that certificate to be revoked anyway.

Resolves #367 