### PR TITLE
add a standalone program to commit the redis cache to disk

### DIFF
--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -6,6 +6,7 @@ RUN mkdir bin gopath
 ENV GOPATH=/build/gopath
 RUN go build -o bin/aggregate-crls /build/cmd/aggregate-crls
 RUN go build -o bin/aggregate-known /build/cmd/aggregate-known
+RUN go build -o bin/commit /build/cmd/commit
 RUN go build -o bin/ct-fetch /build/cmd/ct-fetch
 
 FROM rust:latest AS rust-builder

--- a/containers/scripts/crlite-commit.sh
+++ b/containers/scripts/crlite-commit.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+
+${crlite_bin:-~/go/bin}/commit -stderrthreshold=INFO -alsologtostderr
+
+exit 0

--- a/go/cmd/commit/commit.go
+++ b/go/cmd/commit/commit.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/golang/glog"
+	"github.com/mozilla/crlite/go/config"
+	"github.com/mozilla/crlite/go/engine"
+)
+
+const (
+	permMode    = 0644
+	permModeDir = 0755
+)
+
+var (
+	ctconfig = config.NewCTConfig()
+)
+
+func work() error {
+	ctconfig.Init()
+
+	ctx := context.Background()
+	ctx, cancelMain := context.WithCancel(ctx)
+
+	// Try to handle SIGINT and SIGTERM gracefully
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	defer close(sigChan)
+	go func() {
+		sig := <-sigChan
+		glog.Infof("Signal caught: %s..", sig)
+		cancelMain()
+		signal.Stop(sigChan) // Restore default behavior
+	}()
+
+	certDB, cache := engine.GetConfiguredStorage(ctx, ctconfig, false)
+	defer glog.Flush()
+
+	glog.Infof("Committing DB changes since last run")
+	commitToken, err := cache.AcquireCommitLock()
+	if err != nil || commitToken == nil {
+		return fmt.Errorf("Failed to acquire commit lock: %s", err)
+	}
+	defer cache.ReleaseCommitLock(*commitToken)
+
+	err = certDB.Commit(*commitToken)
+	if err != nil {
+		return fmt.Errorf("Error in commit: %s", err)
+	}
+
+	return nil
+}
+
+func main() {
+	err := work()
+	if err != nil {
+		glog.Fatal(err)
+	}
+}


### PR DESCRIPTION
Resolves #370 

We'll also need to add a cronjob to run crlite-commit.sh hourly, but that lives in a private cloudops repo.