### PR TITLE
rust-query-crlite: use enrolled.json rather than ccadb report

### DIFF
--- a/moz_kinto_publisher/main.py
+++ b/moz_kinto_publisher/main.py
@@ -751,9 +751,9 @@ def publish_crlite_record(
     #   await FilterExpressions.eval(expression, context)
     # See https://remote-settings.readthedocs.io/en/latest/target-filters.html
     # for the expression syntax and the definition of env.
-    attributes[
-        "filter_expression"
-    ] = f"env.version|versionCompare('{channel.supported_version}.!') >= 0 && '{channel.slug}' == 'security.pki.crlite_channel'|preferenceValue('none')"
+    attributes["filter_expression"] = (
+        f"env.version|versionCompare('{channel.supported_version}.!') >= 0 && '{channel.slug}' == 'security.pki.crlite_channel'|preferenceValue('none')"
+    )
 
     record = rw_client.create_record(
         collection=settings.KINTO_CRLITE_COLLECTION,


### PR DESCRIPTION
The filter generation process produces a nice JSON file from the CCADB CSV report that the backend uses. Rather than worry about parsing the CSV correctly, we can have rust-query-crlite use the latest enrolled.json file.