### PR TITLE
crlite-signoff: stop enforcing verification_domains.txt check.

### DIFF
--- a/containers/crlite-signoff-config.properties.example
+++ b/containers/crlite-signoff-config.properties.example
@@ -9,18 +9,3 @@ KINTO_AUTH_PASSWORD=kinto_signer_example_password
 # If the variable KINTO_NOOP is set to anything at all, then the signoff will
 # operate as a no-op and simply print what it's doing.
 # KINTO_NOOP=dont_publish_if_this_is_set_to_anything
-
-
-# Hosts to verify as being unrevoked in the filter in the `crlite_filter_bucket`
-# config. The pod will connect to each, obtain the certificate in-use, and
-# evaluate the CRLite filter to ensure it's not revoked.
-#
-# Syntax: comma delimited list of accessible urls, containing lines of hosts as
-#         host[:port]
-# and prefixing lines with # or ; to indicate comments. E.g.:
-#
-#   example.com:8443
-#   ; also the following, port 443 assumed
-#   example.net
-#
-crlite_verify_host_file_urls=https://storage.googleapis.com/crlite-verification-domains/mozilla-services-domains.txt, https://storage.googleapis.com/crlite-verification-domains/moz-top500.txt

--- a/containers/scripts/crlite-signoff.sh
+++ b/containers/scripts/crlite-signoff.sh
@@ -23,20 +23,13 @@ fi
 # sign off on intermediates
 python3 "${SCRIPTS}/crlite-signoff-tool.py" intermediates
 
-# sign off on cert-revocations if the verification domains test passes and the
-# filter is less than MAX_FILTER_SIZE.
+# sign off on cert-revocations if the filter is less than MAX_FILTER_SIZE.
 FILTER_SIZE=$(stat --format=%s "${OUTPUT}/crlite.filter")
 echo "Filter is ${FILTER_SIZE} bytes."
 
 if (( FILTER_SIZE > MAX_FILTER_SIZE ))
 then
   echo "Cannot automatically sign off on a filter larger than max_filter_size=${MAX_FILTER_SIZE} bytes."
-  exit 1;
-fi
-
-if ! "${RUST_QUERY_CRLITE}" -v --db "${OUTPUT}" --update "${INSTANCE}" signoff "${crlite_verify_host_file_urls}"
-then
-  echo "Verification domains test failed"
   exit 1;
 fi
 


### PR DESCRIPTION
The verification domains check is supposed to stop us from publishing a filter that would block access to critical infrastructure. It fetches certificates from a list of TLS servers and checks that none of them are marked as revoked. The check fails closed, so a temporary outage at one of the servers or a failure to fetch, say, the CCADB intermediate certificate list causes us to halt filter publication.

The verification domains check was plausibly useful when our CRLite implementation suffered from false positives. Now it just has a tendency to halt publication. If we were to ever publish a filter that blocked access to critical Firefox infrastructure, we would simply rotate the certificate on the affected server and/or publish new filters.