### PR TITLE
Save v4 encoded clubcards in cloud storage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - run:
           name: rustfmt
-          command: rustfmt --check src/*.rs
+          command: rustfmt --check src/*.rs src/bin/*.rs
       - run:
           name: Run Tests
           command: cargo test -r

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -44,6 +44,7 @@ VOLUME /var/log /processing /persistent
 
 COPY --from=go-builder /build/bin /app/
 COPY --from=rust-builder /build/release/rust-create-cascade /app/
+COPY --from=rust-builder /build/release/transcode-clubcard /app/
 COPY --from=rust-builder /build/release/rust-query-crlite /app/
 
 COPY moz_kinto_publisher /app/moz_kinto_publisher

--- a/rust-create-cascade/Cargo.toml
+++ b/rust-create-cascade/Cargo.toml
@@ -14,6 +14,6 @@ rust_cascade = { version = "1.5.0" , features = ["builder"] }
 statsd = "0.16.0"
 stderrlog = "0.5"
 tempfile = "3.10.1"
-clubcard = { version = "0.3", features = ["builder"] }
-clubcard-crlite = { version = "0.3.2", features = ["builder"] }
+clubcard = { version = "0.3.3", features = ["builder"] }
+clubcard-crlite = { version = "0.6.1", features = ["builder"] }
 serde_json = "1"

--- a/rust-create-cascade/src/bin/transcode-clubcard.rs
+++ b/rust-create-cascade/src/bin/transcode-clubcard.rs
@@ -1,0 +1,98 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! # transcode-clubcard
+//!
+//! Reads a CRLite clubcard and writes an equivalent clubcard in a different serialization
+//! format.
+//!
+//! A run of `rust-create-cascade` emits a single encoding. We want to publish both the V3
+//! and the V4 encoding of each clubcard while clients migrate, so the workflow builds the
+//! V3 encoding and uses this program to derive the V4 copy from it.
+
+extern crate clap;
+extern crate clubcard_crlite;
+extern crate log;
+extern crate stderrlog;
+
+use clap::Parser;
+use clubcard_crlite::CRLiteClubcard;
+use log::*;
+use std::path::PathBuf;
+
+/// Serialization format for clubcard filters.
+///
+/// `bincode` is the legacy V3 encoding; `tls` is the V4 encoding that uses a
+/// TLS-presentation-language-style codec.
+#[derive(clap::ValueEnum, Copy, Clone, PartialEq)]
+enum ClubcardEncoding {
+    Bincode,
+    Tls,
+}
+
+impl From<ClubcardEncoding> for clubcard_crlite::Encoding {
+    fn from(encoding: ClubcardEncoding) -> clubcard_crlite::Encoding {
+        match encoding {
+            ClubcardEncoding::Bincode => clubcard_crlite::Encoding::V3,
+            ClubcardEncoding::Tls => clubcard_crlite::Encoding::V4,
+        }
+    }
+}
+
+#[derive(Parser)]
+struct Cli {
+    /// Clubcard to read. Its encoding is taken from its header, not from --encoding.
+    #[clap(long, parse(from_os_str))]
+    input: PathBuf,
+    /// Where to write the re-encoded clubcard.
+    #[clap(long, parse(from_os_str))]
+    output: PathBuf,
+    #[clap(long, value_enum, default_value = "tls")]
+    encoding: ClubcardEncoding,
+    #[clap(long)]
+    clobber: bool,
+    #[clap(short = 'v', parse(from_occurrences))]
+    verbose: usize,
+}
+
+fn main() {
+    let args = Cli::parse();
+
+    stderrlog::new()
+        .module(module_path!())
+        .verbosity(args.verbose)
+        .init()
+        .unwrap();
+
+    if args.output.exists() && !args.clobber {
+        error!(
+            "{} exists! Will not overwrite without --clobber.",
+            args.output.display()
+        );
+        std::process::exit(1);
+    }
+
+    let input_bytes = std::fs::read(&args.input).expect("cannot read input file");
+    let clubcard = CRLiteClubcard::from_bytes(&input_bytes).expect("cannot deserialize clubcard");
+    info!(
+        "Read {} ({} bytes)",
+        args.input.display(),
+        input_bytes.len()
+    );
+    info!("{}", clubcard);
+
+    let output_bytes = clubcard
+        .to_bytes(args.encoding.into())
+        .expect("cannot serialize clubcard");
+
+    info!("Testing deserialization");
+    CRLiteClubcard::from_bytes(&output_bytes).expect("cannot deserialize re-encoded clubcard");
+
+    std::fs::write(&args.output, &output_bytes).expect("cannot write output file");
+    info!(
+        "Wrote {} ({} bytes)",
+        args.output.display(),
+        output_bytes.len()
+    );
+}

--- a/rust-create-cascade/src/clubcard_helper.rs
+++ b/rust-create-cascade/src/clubcard_helper.rs
@@ -8,7 +8,9 @@ use crate::{
 };
 use clubcard::{builder::*, Clubcard};
 
-use clubcard_crlite::{builder::*, CRLiteClubcard, CRLiteCoverage, CRLiteKey, CRLiteQuery};
+use clubcard_crlite::{
+    builder::*, CRLiteClubcard, CRLiteCoverage, CRLiteKey, CRLiteQuery, Encoding, IssuerSpkiHash,
+};
 
 use log::*;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
@@ -31,7 +33,7 @@ fn clubcard_do_one_issuer(
     for (_expiry, serial) in known_serials {
         universe_size += 1;
         if revoked_serial_set.contains(&serial) {
-            let key = CRLiteBuilderItem::revoked(*issuer, decode_serial(&serial));
+            let key = CRLiteBuilderItem::revoked(IssuerSpkiHash(*issuer), decode_serial(&serial));
             ribbon_builder.insert(key);
             // Ensure that we do not attempt to include this issuer+serial again.
             revoked_serial_set.remove(&serial);
@@ -98,9 +100,9 @@ impl FilterBuilder for ClubcardBuilder<4, CRLiteBuilderItem> {
         for (_expiry, serial) in known_serials {
             let serial_bytes = decode_serial(&serial);
             let key = if revoked_serial_set.contains(&serial) {
-                CRLiteBuilderItem::revoked(*issuer, serial_bytes)
+                CRLiteBuilderItem::revoked(IssuerSpkiHash(*issuer), serial_bytes)
             } else {
-                CRLiteBuilderItem::not_revoked(*issuer, serial_bytes)
+                CRLiteBuilderItem::not_revoked(IssuerSpkiHash(*issuer), serial_bytes)
             };
             ribbon_builder.insert(key);
         }
@@ -128,9 +130,10 @@ impl CheckableFilter for CRLiteClubcard {
             .map(|iter| iter.into())
             .unwrap_or_default();
 
+        let issuer_hash = IssuerSpkiHash(*issuer);
         for (_expiry, serial) in known_serials {
             let decoded_serial = decode_serial(&serial);
-            let key = CRLiteKey::new(issuer, &decoded_serial);
+            let key = CRLiteKey::new(&issuer_hash, &decoded_serial);
             let query = CRLiteQuery::new(&key, None);
             assert!(
                 Clubcard::unchecked_contains(self.as_ref(), &query)
@@ -146,6 +149,7 @@ pub fn create_clubcard(
     known_dir: &Path,
     coverage_path: &Path,
     reason_set: ReasonSet,
+    encoding: Encoding,
 ) -> Vec<u8> {
     let coverage = CRLiteCoverage::from_mozilla_ct_logs_json(BufReader::new(
         std::fs::File::open(coverage_path).unwrap(),
@@ -165,7 +169,7 @@ pub fn create_clubcard(
     info!("Generated {}", clubcard);
 
     info!("Testing serialization");
-    let clubcard_bytes = clubcard.to_bytes().expect("cannot serialize clubcard");
+    let clubcard_bytes = clubcard.to_bytes(encoding).expect("cannot serialize clubcard");
     info!("Clubcard is {} bytes", clubcard_bytes.len());
 
     let clubcard =

--- a/rust-create-cascade/src/main.rs
+++ b/rust-create-cascade/src/main.rs
@@ -682,6 +682,25 @@ enum FilterType {
     Clubcard,
 }
 
+/// Serialization format for clubcard filters. Ignored for cascade filters.
+///
+/// `bincode` is the legacy V3 encoding; `tls` is the V4 encoding that uses a
+/// TLS-presentation-language-style codec.
+#[derive(clap::ValueEnum, Copy, Clone, PartialEq)]
+enum ClubcardEncoding {
+    Bincode,
+    Tls,
+}
+
+impl From<ClubcardEncoding> for clubcard_crlite::Encoding {
+    fn from(encoding: ClubcardEncoding) -> clubcard_crlite::Encoding {
+        match encoding {
+            ClubcardEncoding::Bincode => clubcard_crlite::Encoding::V3,
+            ClubcardEncoding::Tls => clubcard_crlite::Encoding::V4,
+        }
+    }
+}
+
 #[derive(Parser)]
 struct Cli {
     #[clap(long, parse(from_os_str), default_value = "./known/")]
@@ -704,6 +723,8 @@ struct Cli {
     murmurhash3: bool,
     #[clap(long, value_enum, default_value = "cascade")]
     filter_type: FilterType,
+    #[clap(long, value_enum, default_value = "bincode")]
+    encoding: ClubcardEncoding,
     #[clap(long)]
     clobber: bool,
     #[clap(short = 'v', parse(from_occurrences))]
@@ -727,6 +748,7 @@ fn main() {
     let reason_set = args.reason_set;
     let delta_reason_set = args.delta_reason_set;
     let filter_type = args.filter_type;
+    let encoding = args.encoding;
     let ct_logs_json = &args.ct_logs_json;
 
     let out_dir = &args.outdir;
@@ -848,6 +870,7 @@ fn main() {
                 known_dir,
                 ct_logs_json,
                 reason_set,
+                encoding.into(),
             )
         }
         FilterType::Cascade => {
@@ -915,6 +938,7 @@ fn main() {
                 known_dir,
                 ct_logs_json,
                 delta_reason_set,
+                encoding.into(),
             )
         }
         FilterType::Cascade => {
@@ -1006,7 +1030,7 @@ mod tests {
         decode_issuer, decode_serial, write_revset_and_delta, write_stash, CheckableFilter, Reason,
         ReasonSet,
     };
-    use clubcard_crlite::CRLiteClubcard;
+    use clubcard_crlite::{CRLiteClubcard, Encoding};
     use rand::rngs::OsRng;
     use rand::RngCore;
     use rust_cascade::{Cascade, HashAlgorithm};
@@ -1352,6 +1376,7 @@ mod tests {
             &env.known_dir(),
             &env.ct_logs_path(),
             ReasonSet::All,
+            Encoding::V4,
         );
         assert!(
             Cascade::from_bytes(clubcard_bytes).is_err(),

--- a/rust-query-crlite/Cargo.toml
+++ b/rust-query-crlite/Cargo.toml
@@ -9,7 +9,7 @@ bincode = "1.3"
 byteorder = "1.2.7"
 clap = { version = "4.5", features = ["derive"] }
 clubcard = "0.3"
-clubcard-crlite = "0.3"
+clubcard-crlite = "0.6"
 der-parser = "9.0"
 hex = "0.4"
 log = "0.4"

--- a/rust-query-crlite/src/main.rs
+++ b/rust-query-crlite/src/main.rs
@@ -19,7 +19,7 @@ extern crate stderrlog;
 extern crate x509_parser;
 
 use clap::Parser;
-use clubcard_crlite::{CRLiteClubcard, CRLiteStatus};
+use clubcard_crlite::{CRLiteClubcard, CRLiteStatus, IssuerSpkiHash, LogId, Timestamp};
 use der_parser::oid;
 use log::*;
 use serde::Deserialize;
@@ -272,8 +272,12 @@ impl Filter {
     ) -> Status {
         match self {
             Filter::Clubcard((_, clubcard)) => {
-                let crlite_key = clubcard_crlite::CRLiteKey::new(issuer_spki_hash, serial);
-                match clubcard.contains(&crlite_key, timestamps.iter().map(|(x, y)| (x, *y))) {
+                let issuer_spki_hash = IssuerSpkiHash(issuer_spki_hash.clone());
+                let crlite_key = clubcard_crlite::CRLiteKey::new(&issuer_spki_hash, serial);
+                match clubcard.contains(
+                    &crlite_key,
+                    timestamps.iter().map(|(x, y)| (LogId(*x), Timestamp(*y))),
+                ) {
                     CRLiteStatus::Good => Status::Good,
                     CRLiteStatus::NotCovered => Status::NotCovered,
                     CRLiteStatus::NotEnrolled => Status::NotEnrolled,

--- a/workflow/2-generate_mlbf
+++ b/workflow/2-generate_mlbf
@@ -103,6 +103,25 @@ def main():
     log.info(f"Running {cmdline}")
     subprocess.run(cmdline, check=True)
 
+    if filter_type == "clubcard":
+        # rust-create-cascade writes the V3 encoding. Derive a V4 copy of each clubcard and
+        # write it alongside.
+        transcode_exe = os.path.expanduser("~/transcode-clubcard")
+        for name in ("filter", "filter.delta"):
+            transcode_cmdline = [
+                transcode_exe,
+                "-vv",
+                "--input",
+                os.path.join(outdir, name),
+                "--output",
+                os.path.join(outdir, f"{name}.v4"),
+                "--encoding",
+                "tls",
+                "--clobber",
+            ]
+            log.info(f"Running {transcode_cmdline}")
+            subprocess.run(transcode_cmdline, check=True)
+
 
 if __name__ == "__main__":
     main()

--- a/workflow/3-upload_mlbf_to_storage
+++ b/workflow/3-upload_mlbf_to_storage
@@ -69,6 +69,7 @@ def main():
     runIdPath = args.results_path[0].resolve()
 
     ensureFileOrAbort(runIdPath, Path("clubcard-all/filter"))
+    ensureFileOrAbort(runIdPath, Path("clubcard-all/filter.v4"))
 
     for path, dirs, files in os.walk(runIdPath / "clubcard-all"):
         localFolder = Path(path)


### PR DESCRIPTION
We currently create, store, and publish Clubcards in the v3 (bincode) format. As a first step towards switching to the v4 format, this PR saves v4 encoded clubcards in our public cloud storage. This will allow non-Firefox consumers of CRLite data to switch to the v4 format before Firefox.